### PR TITLE
fix: remove fieldset/legend wrapping single-control form components

### DIFF
--- a/packages/react/src/__tests__/form/ColorPicker.test.tsx
+++ b/packages/react/src/__tests__/form/ColorPicker.test.tsx
@@ -8,6 +8,12 @@ describe('ColorPicker', () => {
     expect(screen.getByText('Brand Color')).toBeInTheDocument();
   });
 
+  it('does not wrap a single color input in a fieldset/legend', () => {
+    const { container } = render(<ColorPicker label="Brand Color" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
   it('renders color input', () => {
     render(<ColorPicker label="Color" />);
     const input = screen.getByLabelText('Color');

--- a/packages/react/src/__tests__/form/DatePicker.test.tsx
+++ b/packages/react/src/__tests__/form/DatePicker.test.tsx
@@ -8,6 +8,18 @@ describe('DatePicker', () => {
     expect(screen.getByText('Start Date')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<DatePicker label="Start Date" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<DatePicker id="start" label="Start Date" />);
+    const input = screen.getByLabelText('Start Date');
+    expect(input).toHaveAttribute('id', 'start');
+  });
+
   it('renders date input by default', () => {
     const { container } = render(<DatePicker label="Date" />);
     const input = container.querySelector('input[type="date"]');

--- a/packages/react/src/__tests__/form/Editor.test.tsx
+++ b/packages/react/src/__tests__/form/Editor.test.tsx
@@ -8,6 +8,18 @@ describe('Editor', () => {
     expect(screen.getByText('Code')).toBeInTheDocument();
   });
 
+  it('does not wrap a single textarea in a fieldset/legend', () => {
+    const { container } = render(<Editor label="Code" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the textarea via htmlFor/id', () => {
+    render(<Editor id="snippet" label="Code" />);
+    const textarea = screen.getByLabelText('Code');
+    expect(textarea).toHaveAttribute('id', 'snippet');
+  });
+
   it('renders textarea', () => {
     render(<Editor label="Code" />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/File.test.tsx
+++ b/packages/react/src/__tests__/form/File.test.tsx
@@ -8,6 +8,18 @@ describe('File', () => {
     expect(screen.getByText('Upload')).toBeInTheDocument();
   });
 
+  it('does not wrap a single file input in a fieldset/legend', () => {
+    const { container } = render(<File label="Upload" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('does not wrap a drag-drop file input in a fieldset/legend', () => {
+    const { container } = render(<File label="Upload" withDragDrop />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
   it('renders file input', () => {
     const { container } = render(<File label="Upload" />);
     const input = container.querySelector('input[type="file"]');

--- a/packages/react/src/__tests__/form/Input.test.tsx
+++ b/packages/react/src/__tests__/form/Input.test.tsx
@@ -94,6 +94,11 @@ describe('Input', () => {
     expect(onClear).toHaveBeenCalledOnce();
   });
 
+  it('keeps the clear button keyboard-focusable', () => {
+    render(<Input label="Search" clearable onClear={() => {}} />);
+    expect(screen.getByLabelText('Clear input')).not.toHaveAttribute('tabindex', '-1');
+  });
+
   it('renders inline label as a floating label associated with the input', () => {
     const { container } = render(<Input id="city" label="City" inline />);
     expect(container.querySelector('fieldset')).not.toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Input.test.tsx
+++ b/packages/react/src/__tests__/form/Input.test.tsx
@@ -8,6 +8,34 @@ describe('Input', () => {
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<Input label="Email" type="email" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<Input label="Email" type="email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input).toHaveAttribute('id');
+    expect(input.id).toBeTruthy();
+  });
+
+  it('renders the visible label with the daisyUI v5 fieldset-legend class', () => {
+    render(<Input id="email" label="Email" type="email" />);
+    const labelEl = screen.getByText('Email').closest('label');
+    expect(labelEl).toBeInTheDocument();
+    expect(labelEl).toHaveClass('fieldset-legend');
+    expect(labelEl).toHaveAttribute('for', 'email');
+  });
+
+  it('uses an explicit caller-provided id', () => {
+    render(<Input id="user-email" label="Email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('id', 'user-email');
+  });
+
   it('renders hint text', () => {
     render(<Input label="Email" hint="We will never share your email" />);
     expect(screen.getByText('We will never share your email')).toBeInTheDocument();
@@ -28,6 +56,18 @@ describe('Input', () => {
   it('sets aria-invalid when error is present', () => {
     render(<Input label="Email" error="Required" />);
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('wires aria-describedby to the hint when present', () => {
+    render(<Input id="phone" label="Phone" hint="Numbers only" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'phone-hint');
+  });
+
+  it('wires aria-describedby to the error when present', () => {
+    render(<Input id="phone" label="Phone" error="Required" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'phone-error');
   });
 
   it('shows required indicator', () => {
@@ -54,9 +94,29 @@ describe('Input', () => {
     expect(onClear).toHaveBeenCalledOnce();
   });
 
-  it('renders inline label', () => {
-    render(<Input label="Floating" inline />);
-    expect(screen.getByText('Floating')).toHaveClass('label');
+  it('renders inline label as a floating label associated with the input', () => {
+    const { container } = render(<Input id="city" label="City" inline />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+    const wrapper = container.querySelector('label.floating-label');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute('for', 'city');
+    const input = screen.getByLabelText('City');
+    expect(input).toHaveAttribute('id', 'city');
+    expect(wrapper?.contains(input)).toBe(true);
+    expect(input).toHaveAttribute('placeholder', ' ');
+  });
+
+  it('does not inject a single-space placeholder in non-inline mode', () => {
+    render(<Input id="city" label="City" />);
+    const input = screen.getByLabelText('City');
+    expect(input).not.toHaveAttribute('placeholder');
+  });
+
+  it('preserves a caller-provided placeholder in inline mode', () => {
+    render(<Input id="city" label="City" inline placeholder="Type a city" />);
+    const input = screen.getByLabelText('City');
+    expect(input).toHaveAttribute('placeholder', 'Type a city');
   });
 
   it('forwards ref', () => {

--- a/packages/react/src/__tests__/form/Password.test.tsx
+++ b/packages/react/src/__tests__/form/Password.test.tsx
@@ -8,6 +8,18 @@ describe('Password', () => {
     expect(screen.getByText('Password')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<Password label="Password" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<Password id="user-pw" label="Password" />);
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveAttribute('id', 'user-pw');
+  });
+
   it('renders as password type by default', () => {
     const { container } = render(<Password label="Password" />);
     const input = container.querySelector('input');

--- a/packages/react/src/__tests__/form/Password.test.tsx
+++ b/packages/react/src/__tests__/form/Password.test.tsx
@@ -45,6 +45,16 @@ describe('Password', () => {
     expect(screen.queryByLabelText('Show password')).not.toBeInTheDocument();
   });
 
+  it('keeps the visibility toggle keyboard-focusable', () => {
+    render(<Password label="Password" />);
+    expect(screen.getByLabelText('Show password')).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('keeps the clear button keyboard-focusable', () => {
+    render(<Password label="Password" clearable onClear={() => {}} />);
+    expect(screen.getByLabelText('Clear password')).not.toHaveAttribute('tabindex', '-1');
+  });
+
   it('renders error', () => {
     render(<Password label="Password" error="Too short" />);
     expect(screen.getByText('Too short')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Pin.test.tsx
+++ b/packages/react/src/__tests__/form/Pin.test.tsx
@@ -9,6 +9,13 @@ describe('Pin', () => {
     expect(inputs).toHaveLength(4);
   });
 
+  it('does not wrap inputs in a fieldset/legend', () => {
+    const { container } = render(<Pin length={4} />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+    expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'PIN input');
+  });
+
   it('renders 6 inputs', () => {
     render(<Pin length={6} />);
     const inputs = screen.getAllByRole('textbox');

--- a/packages/react/src/__tests__/form/Range.test.tsx
+++ b/packages/react/src/__tests__/form/Range.test.tsx
@@ -8,6 +8,18 @@ describe('Range', () => {
     expect(screen.getByText('Volume')).toBeInTheDocument();
   });
 
+  it('does not wrap a single slider in a fieldset/legend', () => {
+    const { container } = render(<Range label="Volume" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the slider via htmlFor/id', () => {
+    render(<Range id="vol" label="Volume" />);
+    const slider = screen.getByLabelText('Volume');
+    expect(slider).toHaveAttribute('id', 'vol');
+  });
+
   it('renders as range input', () => {
     render(<Range label="Volume" />);
     expect(screen.getByRole('slider')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/RichTextEditor.test.tsx
+++ b/packages/react/src/__tests__/form/RichTextEditor.test.tsx
@@ -8,6 +8,19 @@ describe('RichTextEditor', () => {
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
+  it('does not wrap the editor in a fieldset/legend', () => {
+    const { container } = render(<RichTextEditor label="Content" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the contenteditable region via aria-labelledby', () => {
+    render(<RichTextEditor id="content-editor" label="Content" />);
+    const editor = screen.getByLabelText('Content');
+    expect(editor).toHaveAttribute('id', 'content-editor');
+    expect(editor).toHaveAttribute('aria-labelledby', 'content-editor-label');
+  });
+
   it('renders contentEditable area', () => {
     render(<RichTextEditor label="Content" />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Select.test.tsx
+++ b/packages/react/src/__tests__/form/Select.test.tsx
@@ -14,6 +14,19 @@ describe('Select', () => {
     expect(screen.getByText('Country')).toBeInTheDocument();
   });
 
+  it('does not wrap a single select in a fieldset/legend', () => {
+    const { container } = render(<Select label="Country" options={options} />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the select via htmlFor/id', () => {
+    render(<Select id="country" label="Country" options={options} />);
+    const select = screen.getByLabelText('Country');
+    expect(select).toBeInstanceOf(HTMLSelectElement);
+    expect(select).toHaveAttribute('id', 'country');
+  });
+
   it('renders options', () => {
     render(<Select label="Country" options={options} />);
     expect(screen.getByText('Option 1')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Textarea.test.tsx
+++ b/packages/react/src/__tests__/form/Textarea.test.tsx
@@ -8,6 +8,19 @@ describe('Textarea', () => {
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
+  it('does not wrap a single textarea in a fieldset/legend', () => {
+    const { container } = render(<Textarea label="Description" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the textarea via htmlFor/id', () => {
+    render(<Textarea id="bio" label="Bio" />);
+    const textarea = screen.getByLabelText('Bio');
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+    expect(textarea).toHaveAttribute('id', 'bio');
+  });
+
   it('renders hint', () => {
     render(<Textarea label="Bio" hint="Max 500 characters" />);
     expect(screen.getByText('Max 500 characters')).toBeInTheDocument();

--- a/packages/react/src/components/form/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/form/ColorPicker/ColorPicker.tsx
@@ -129,16 +129,15 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
     }, [onRandomColor]);
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label
+        <span
           className={cn('input w-full', error && 'input-error', className)}
-          htmlFor={id}
           style={{ paddingInlineStart: 0, overflow: 'hidden' }}
         >
           <input
@@ -221,7 +220,7 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
               {iconRight}
             </span>
           )}
-        </label>
+        </span>
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -232,7 +231,7 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/form/DatePicker/DatePicker.tsx
@@ -71,55 +71,76 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     const errorId = error ? `${id}-error` : undefined;
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
-    const hasAdornments = icon || iconRight || inline;
+    const hasAdornments = icon || iconRight;
+
+    const commonInputProps = {
+      ref,
+      id,
+      type: dateType,
+      'aria-invalid': error ? true : undefined,
+      'aria-describedby': describedBy,
+      'aria-required': required || undefined,
+      required,
+      // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+      // floating-label CSS positions/animates the label correctly without showing visible text.
+      placeholder: rest.placeholder ?? (inline && label ? ' ' : undefined),
+      ...rest,
+    } as const;
+
+    const dateInput = hasAdornments ? (
+      <span className={cn('input w-full', error && 'input-error', className)}>
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <input className="grow" style={{ height: 'auto' }} {...commonInputProps} />
+        {iconRight && (
+          <span className="opacity-50" aria-hidden="true">
+            {iconRight}
+          </span>
+        )}
+      </span>
+    ) : (
+      <input
+        className={cn('input w-full', error && 'input-error', className)}
+        {...commonInputProps}
+      />
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {dateInput}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
 
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
-        )}
-        {hasAdornments ? (
-          <label className={cn('input w-full', error && 'input-error', className)} htmlFor={id}>
-            {icon && (
-              <span className="opacity-50" aria-hidden="true">
-                {icon}
-              </span>
-            )}
-            <input
-              ref={ref}
-              id={id}
-              type={dateType}
-              className="grow"
-              style={{ height: 'auto' }}
-              aria-invalid={error ? true : undefined}
-              aria-describedby={describedBy}
-              aria-required={required || undefined}
-              required={required}
-              {...rest}
-            />
-            {inline && label && <span className="label">{label}</span>}
-            {iconRight && (
-              <span className="opacity-50" aria-hidden="true">
-                {iconRight}
-              </span>
-            )}
           </label>
-        ) : (
-          <input
-            ref={ref}
-            id={id}
-            type={dateType}
-            className={cn('input w-full', error && 'input-error', className)}
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
         )}
+        {dateInput}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -130,7 +151,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Editor/Editor.tsx
+++ b/packages/react/src/components/form/Editor/Editor.tsx
@@ -44,14 +44,12 @@ export const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
-            <label htmlFor={id}>
-              {label}
-              {required && <span className="text-error ml-1">*</span>}
-            </label>
-          </legend>
+          <label htmlFor={id} className="fieldset-legend">
+            {label}
+            {required && <span className="text-error ml-1">*</span>}
+          </label>
         )}
         <textarea
           ref={ref}
@@ -74,7 +72,7 @@ export const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/File/File.tsx
+++ b/packages/react/src/components/form/File/File.tsx
@@ -129,12 +129,12 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
 
     if (withDragDrop) {
       return (
-        <fieldset className="fieldset">
+        <div className="fieldset w-full">
           {label && (
-            <legend className="fieldset-legend">
+            <label htmlFor={id} className="fieldset-legend">
               {label}
               {required && <span className="text-error ml-1">*</span>}
-            </legend>
+            </label>
           )}
           <div
             className={cn(
@@ -188,17 +188,17 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
               {error}
             </p>
           )}
-        </fieldset>
+        </div>
       );
     }
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <input
           ref={setRefs}
@@ -229,7 +229,7 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -131,7 +131,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={onClear}
             aria-label="Clear input"
-            tabIndex={-1}
           >
             ✕
           </button>

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -29,14 +29,20 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
   clearable?: boolean;
   /** Callback fired when the clear button is clicked. Use this to reset the input value. */
   onClear?: () => void;
-  /** When true, renders the label as a floating/inline label inside the input wrapper. @defaultValue `false` */
+  /** When true, renders the label as a floating label using daisyUI's `floating-label` pattern. @defaultValue `false` */
   inline?: boolean;
 }
 
 /**
- * A text input component with DaisyUI styling, supporting labels, hint/error text,
+ * A text input component with daisyUI v5 styling, supporting labels, hint/error text,
  * left/right icons, prefix/suffix adornments, a clearable action button, and
- * an inline (floating) label mode. Automatically generates accessible IDs and ARIA attributes.
+ * a floating label mode. Automatically generates accessible IDs and ARIA attributes.
+ *
+ * Renders the canonical accessible pattern for a single labeled input: a `<label htmlFor>`
+ * paired with the `<input id>`. The visible label and helper text use daisyUI v5's
+ * `.fieldset`, `.fieldset-legend`, and `.fieldset-label` utility classes on plain
+ * elements — `<fieldset>`/`<legend>` HTML elements are reserved for groups of related
+ * controls (e.g. radio/checkbox groups) and are intentionally not used here.
  *
  * @example
  * ```tsx
@@ -81,67 +87,96 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const errorId = error ? `${id}-error` : undefined;
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
+    const inputBox = (
+      <span
+        className={cn(
+          'input',
+          'w-full',
+          (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
+          error && 'input-error',
+          className,
+        )}
+      >
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        {prefix && (
+          <span className="opacity-50" aria-hidden="true">
+            {prefix}
+          </span>
+        )}
+        <input
+          ref={ref}
+          id={id}
+          className="grow"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          required={required}
+          // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+          // floating-label CSS positions/animates the label correctly without showing visible text.
+          placeholder={rest.placeholder ?? (inline && label ? ' ' : undefined)}
+          {...rest}
+        />
+        {suffix && (
+          <span className="opacity-50" aria-hidden="true">
+            {suffix}
+          </span>
+        )}
+        {clearable && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={onClear}
+            aria-label="Clear input"
+            tabIndex={-1}
+          >
+            ✕
+          </button>
+        )}
+        {iconRight && (
+          <span className="opacity-50" aria-hidden="true">
+            {iconRight}
+          </span>
+        )}
+      </span>
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {inputBox}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
+
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label
-          className={cn(
-            'input',
-            'w-full',
-            (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
-            error && 'input-error',
-            className,
-          )}
-          htmlFor={id}
-        >
-          {icon && (
-            <span className="opacity-50" aria-hidden="true">
-              {icon}
-            </span>
-          )}
-          {prefix && (
-            <span className="opacity-50" aria-hidden="true">
-              {prefix}
-            </span>
-          )}
-          <input
-            ref={ref}
-            id={id}
-            className="grow"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
-          {inline && label && <span className="label">{label}</span>}
-          {suffix && (
-            <span className="opacity-50" aria-hidden="true">
-              {suffix}
-            </span>
-          )}
-          {clearable && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={onClear}
-              aria-label="Clear input"
-              tabIndex={-1}
-            >
-              ✕
-            </button>
-          )}
-          {iconRight && (
-            <span className="opacity-50" aria-hidden="true">
-              {iconRight}
-            </span>
-          )}
-        </label>
+        {inputBox}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -152,7 +187,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Password/Password.tsx
+++ b/packages/react/src/components/form/Password/Password.tsx
@@ -106,55 +106,85 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
 
     const [visible, setVisible] = useState(false);
 
+    const passwordBox = (
+      <span className={cn('input w-full', error && 'input-error', className)}>
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <input
+          ref={ref}
+          id={id}
+          type={visible ? 'text' : 'password'}
+          className="grow"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          required={required}
+          // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+          // floating-label CSS positions/animates the label correctly without showing visible text.
+          placeholder={rest.placeholder ?? (inline && label ? ' ' : undefined)}
+          {...rest}
+        />
+        {clearable && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={onClear}
+            aria-label="Clear password"
+            tabIndex={-1}
+          >
+            ✕
+          </button>
+        )}
+        {!hideToggle && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={() => setVisible((v) => !v)}
+            aria-label={visible ? 'Hide password' : 'Show password'}
+            tabIndex={-1}
+          >
+            {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
+          </button>
+        )}
+      </span>
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {passwordBox}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
+
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label className={cn('input w-full', error && 'input-error', className)} htmlFor={id}>
-          {icon && (
-            <span className="opacity-50" aria-hidden="true">
-              {icon}
-            </span>
-          )}
-          <input
-            ref={ref}
-            id={id}
-            type={visible ? 'text' : 'password'}
-            className="grow"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
-          {inline && label && <span className="label">{label}</span>}
-          {clearable && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={onClear}
-              aria-label="Clear password"
-              tabIndex={-1}
-            >
-              ✕
-            </button>
-          )}
-          {!hideToggle && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={() => setVisible((v) => !v)}
-              aria-label={visible ? 'Hide password' : 'Show password'}
-              tabIndex={-1}
-            >
-              {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
-            </button>
-          )}
-        </label>
+        {passwordBox}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -165,7 +195,7 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Password/Password.tsx
+++ b/packages/react/src/components/form/Password/Password.tsx
@@ -133,7 +133,6 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={onClear}
             aria-label="Clear password"
-            tabIndex={-1}
           >
             ✕
           </button>
@@ -144,7 +143,6 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={() => setVisible((v) => !v)}
             aria-label={visible ? 'Hide password' : 'Show password'}
-            tabIndex={-1}
           >
             {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
           </button>

--- a/packages/react/src/components/form/Pin/Pin.tsx
+++ b/packages/react/src/components/form/Pin/Pin.tsx
@@ -179,7 +179,7 @@ export const Pin = forwardRef<HTMLInputElement, PinProps>(
     );
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         <div className="flex gap-2" role="group" aria-label="PIN input">
           {Array.from({ length }).map((_, index) => (
             <input
@@ -222,7 +222,7 @@ export const Pin = forwardRef<HTMLInputElement, PinProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Range/Range.tsx
+++ b/packages/react/src/components/form/Range/Range.tsx
@@ -56,12 +56,12 @@ export const Range = forwardRef<HTMLInputElement, RangeProps>(
     const errorId = error ? `${id}-error` : undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <input
           ref={ref}
@@ -86,7 +86,7 @@ export const Range = forwardRef<HTMLInputElement, RangeProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/RichTextEditor/RichTextEditor.tsx
+++ b/packages/react/src/components/form/RichTextEditor/RichTextEditor.tsx
@@ -117,13 +117,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       }
     }, [value]);
 
+    const labelId = label ? `${id}-label` : undefined;
+
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <span id={labelId} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </span>
         )}
         <div
           className={cn('border rounded-lg overflow-hidden', error && 'border-error', className)}
@@ -137,7 +139,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             contentEditable
             role="textbox"
             aria-multiline="true"
-            aria-label={label}
+            aria-labelledby={labelId}
             aria-invalid={error ? true : undefined}
             aria-describedby={describedBy}
             className="p-4 outline-none prose max-w-none"
@@ -160,7 +162,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Select/Select.tsx
+++ b/packages/react/src/components/form/Select/Select.tsx
@@ -99,14 +99,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && !inline && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label className={cn('select', 'w-full', error && 'select-error', className)} htmlFor={id}>
+        <span className={cn('select', 'w-full', error && 'select-error', className)}>
           {icon && (
             <span className="opacity-50" aria-hidden="true">
               {icon}
@@ -143,7 +143,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
               {iconRight}
             </span>
           )}
-        </label>
+        </span>
         {inline && label && (
           <label className="fieldset-label" htmlFor={id}>
             {label}
@@ -159,7 +159,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Textarea/Textarea.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.tsx
@@ -47,12 +47,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && !inline && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <textarea
           ref={ref}
@@ -85,7 +85,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Description

The form components were wrapping each single labeled control in `<fieldset>`/`<legend>`, which is wrong semantics — `<fieldset>` is for **groups** of related controls (radio sets, checkbox groups, related questions), not lone inputs. This caused two real bugs downstream:

1. **Accessibility**: screen readers announced each lone input as "group" (e.g. "Email, group, edit Email") instead of "Email, edit text". Legend re-announced on focus, adding AT verbosity.
2. **Styling**: hosts without daisyUI's reset got the default browser fieldset border around every field. Verified in Keystone CMS consumer (`artisanpack-ui/forms` `TextField` → `Input`).

Fixed by switching every single-control form component to daisyUI v5's `fieldset` *utility class* on a plain `<div>` (not a `<fieldset>` element), paired with a `<label class="fieldset-legend" htmlFor>` and a presentational `<span class="input">` wrapper. Inline mode on `Input`, `Password`, and `DatePicker` now uses daisyUI v5's `floating-label` pattern. `RichTextEditor` uses `aria-labelledby` since `htmlFor` doesn't bind to `contenteditable` divs.

`Radio`, `Checkbox` (group), and `Toggle` keep `<fieldset>`/`<legend>` since they're genuine control groups.

**Closes:** #39

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #39

## Motivation and Context

Reported via downstream Keystone CMS consumer — every contact-form field rendered as a fieldset-wrapped input, both ugly and inaccessible. Root cause was the v4-style markup left over from earlier work; daisyUI v5's `.fieldset` and `.fieldset-legend` are utility classes that work on any element, so we can keep the visual style while using semantically correct HTML.

## Changes Made

- `Input`, `Textarea`, `Password`, `Pin`, `DatePicker`, `Select`, `RichTextEditor`, `Editor`, `File` (both modes), `ColorPicker`, `Range`: replaced `<fieldset class="fieldset">` + `<legend class="fieldset-legend">` with `<div class="fieldset">` + `<label class="fieldset-legend" htmlFor>`.
- `Input`, `Password`, `DatePicker`: inline mode now wraps via `<label class="floating-label">` (daisyUI v5 floating-label pattern); single-space placeholder injected when no caller placeholder is supplied so `:placeholder-shown` triggers correctly.
- `RichTextEditor`: switched from `htmlFor`/`aria-label` to `aria-labelledby` pointing at the legend `<span>`, since `<label htmlFor>` does not associate with a `contenteditable` div.
- `Pin`: dropped `<fieldset>` wrapper; the inner `role="group" aria-label="PIN input"` keeps the digits grouped accessibly.
- `DatePicker`: extracted shared `commonInputProps` object to remove duplication between the adorned and bare input branches.
- Added 17 regression tests across the affected components asserting no `<fieldset>`/`<legend>` wraps a single control and label↔input association is correct.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): Chrome
- Project Version: `@artisanpack-ui/react` 1.0.1-rc

**Tests Performed:**
1. `npx vitest run` — 702/702 pass
2. `npx tsc --noEmit -p packages/react/tsconfig.json` — clean
3. `npx eslint packages/react/src` — clean
4. Verified visually in the Keystone CMS consumer: contact-form fields (text, email, textarea) now render with the label stacked above the input and no fieldset border in hosts without a daisyUI reset.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [ ] Color contrast verified (no color changes)
- [x] ARIA labels checked

**Details:** Verified that lone inputs no longer get announced with the "group" role; `aria-describedby` still wires hint/error nodes correctly; `RichTextEditor`'s `contenteditable` is now properly labeled via `aria-labelledby`.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Added regression tests in `Input`, `Textarea`, `Password`, `Pin`, `DatePicker`, `Select`, `RichTextEditor`, `Editor`, `File`, `ColorPicker`, `Range` test files asserting no `<fieldset>`/`<legend>` wraps a single control. Added label↔input association tests (via `getByLabelText` / `htmlFor` / `aria-labelledby`) for the same set. Strengthened `Input` inline-mode test to assert the input is a descendant of the `floating-label` wrapper and carries the `placeholder=" "` trigger.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Updated the JSDoc on `Input` to document the v5 pattern (and to note that `<fieldset>`/`<legend>` are reserved for control groups). Added inline comments explaining the deliberate single-space placeholder used to trigger `:placeholder-shown` for floating-label CSS.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated form field markup: replaced native fieldset/legend wrappers with div/label structures, standardized floating-label behavior and placeholder handling, and ensured clear/visibility toggle controls remain keyboard-focusable across form components.

* **Tests**
  * Added/expanded tests to verify accessibility: label associations, correct id/htmlFor linkage, and that single inputs are not wrapped in fieldset/legend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/react/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->