### PR TITLE
fix: replace dead daisyUI 4 class names with daisyUI 5 equivalents

### DIFF
--- a/packages/react/src/__tests__/layout/Card.test.tsx
+++ b/packages/react/src/__tests__/layout/Card.test.tsx
@@ -57,14 +57,14 @@ describe('Card', () => {
     expect(container.firstChild).not.toHaveClass('shadow-xl');
   });
 
-  it('applies bordered class', () => {
+  it('applies bordered class (daisyUI v5 card-border)', () => {
     const { container } = render(<Card bordered>Content</Card>);
-    expect(container.firstChild).toHaveClass('card-bordered');
+    expect(container.firstChild).toHaveClass('card-border');
   });
 
-  it('applies compact class', () => {
+  it('applies compact class (daisyUI v5 card-sm)', () => {
     const { container } = render(<Card compact>Content</Card>);
-    expect(container.firstChild).toHaveClass('card-compact');
+    expect(container.firstChild).toHaveClass('card-sm');
   });
 
   it('applies glass effect', () => {

--- a/packages/react/src/__tests__/layout/Tabs.test.tsx
+++ b/packages/react/src/__tests__/layout/Tabs.test.tsx
@@ -79,9 +79,19 @@ describe('Tabs', () => {
     expect(onChange).toHaveBeenCalledWith('tab2');
   });
 
-  it('applies variant class', () => {
+  it('applies variant class (daisyUI v5 naming)', () => {
     render(<Tabs tabs={sampleTabs} variant="lifted" />);
-    expect(screen.getByRole('tablist')).toHaveClass('tabs-lifted');
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-lift');
+  });
+
+  it('maps boxed variant to daisyUI v5 tabs-box', () => {
+    render(<Tabs tabs={sampleTabs} variant="boxed" />);
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-box');
+  });
+
+  it('maps bordered variant to daisyUI v5 tabs-border', () => {
+    render(<Tabs tabs={sampleTabs} variant="bordered" />);
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-border');
   });
 
   it('applies size class', () => {

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -92,7 +92,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         className={cn(
           'input',
           'w-full',
-          (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
           error && 'input-error',
           className,
         )}

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -88,14 +88,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     const inputBox = (
-      <span
-        className={cn(
-          'input',
-          'w-full',
-          error && 'input-error',
-          className,
-        )}
-      >
+      <span className={cn('input', 'w-full', error && 'input-error', className)}>
         {icon && (
           <span className="opacity-50" aria-hidden="true">
             {icon}

--- a/packages/react/src/components/layout/Card/Card.tsx
+++ b/packages/react/src/components/layout/Card/Card.tsx
@@ -146,8 +146,9 @@ export const Card = forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
       'card',
       'bg-base-100',
       !noShadow && 'shadow-xl',
-      bordered && 'card-bordered',
-      compact && 'card-compact',
+      bordered && 'card-border',
+      // daisyUI 5 removed card-compact; card-sm is the closest replacement for "reduced padding".
+      compact && 'card-sm',
       glass && 'glass',
       isHorizontal && 'card-side',
       className,

--- a/packages/react/src/components/layout/Tabs/Tabs.tsx
+++ b/packages/react/src/components/layout/Tabs/Tabs.tsx
@@ -77,9 +77,9 @@ const sizeMap: Record<Size, string> = {
 type Variant = NonNullable<TabsProps['variant']>;
 
 const variantMap: Record<Variant, string> = {
-  bordered: 'tabs-bordered',
-  lifted: 'tabs-lifted',
-  boxed: 'tabs-boxed',
+  bordered: 'tabs-border',
+  lifted: 'tabs-lift',
+  boxed: 'tabs-box',
 };
 
 const colorMap: Record<DaisyColor, string> = {

--- a/packages/react/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/react/src/components/navigation/Navbar/Navbar.tsx
@@ -33,7 +33,7 @@ export interface NavbarProps extends HTMLAttributes<HTMLElement> {
  * ```tsx
  * <Navbar
  *   start={<a className="text-xl font-bold">MyApp</a>}
- *   center={<input type="text" placeholder="Search..." className="input input-bordered" />}
+ *   center={<input type="text" placeholder="Search..." className="input" />}
  *   end={<button className="btn btn-primary">Login</button>}
  *   glass
  * />


### PR DESCRIPTION
## Description

daisyUI 5 renamed and removed several utility classes, leaving the package emitting silent no-ops on hosts that use daisyUI 5. Tabs variants, Card variants, and the now-redundant \`input-bordered\` class on Input were all affected — no visible error, just missing styling.

| daisyUI 4 (dead in 5) | daisyUI 5 |
|---|---|
| \`tabs-bordered\` | \`tabs-border\` |
| \`tabs-lifted\` | \`tabs-lift\` |
| \`tabs-boxed\` | \`tabs-box\` |
| \`card-bordered\` | \`card-border\` |
| \`card-compact\` | removed (use size scale — mapped to \`card-sm\` here) |
| \`input-bordered\` | removed (\`.input\` carries the border by default in v5) |

**Closes:** #36

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #36

## Motivation and Context

Hit while migrating \`artisanpack-ui/visual-editor\` to use this package. On a daisyUI 5 host \`<Tabs variant=\"boxed\" />\` rendered without any visual variant — the \`variant\` prop was a no-op because \`tabs-boxed\` doesn't exist in v5. Same problem on \`<Card bordered />\` and \`<Card compact />\`.

## Changes Made

- \`packages/react/src/components/layout/Tabs/Tabs.tsx\`: \`variantMap\` now emits \`tabs-border\`/\`tabs-lift\`/\`tabs-box\`.
- \`packages/react/src/components/layout/Card/Card.tsx\`: \`bordered\` → \`card-border\`. \`compact\` → \`card-sm\` (with an inline comment noting v5 removed \`card-compact\`).
- \`packages/react/src/components/form/Input/Input.tsx\`: removed the \`input-bordered\` class — v5's \`.input\` already includes the border, so the conditional was dead weight.
- \`packages/react/src/components/navigation/Navbar/Navbar.tsx\`: dropped \`input-bordered\` from the JSDoc example for the same reason.
- Updated Tabs and Card tests to assert the new v5 class names; added regression tests covering all three Tabs variants.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): Chrome
- Project Version: \`@artisanpack-ui/react\` 1.0.1-rc

**Tests Performed:**
1. \`npx vitest run\` — 707/707 pass
2. \`npx tsc --noEmit -p packages/react/tsconfig.json\` — clean
3. \`npx eslint packages/react/src\` — clean
4. \`cr review --base release/1.0.1\` — 0 findings
5. Audited other components against \`node_modules/daisyui/components/*.css\` — no other dead v4 class names remain (verified Drawer, Modal, Menu, Alert, Button, Loading, Progress, Dropdown).

## Accessibility Tests Run

- [ ] Keyboard navigation tested (no a11y-affecting changes)
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Visual-only fix; class-name rename does not affect semantics, keyboard focus, or ARIA.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Updated existing Tabs/Card variant tests to assert v5 class names; added two new Tabs tests covering \`boxed\` and \`bordered\` variants explicitly.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Added an inline comment on Card noting that daisyUI v5 removed \`card-compact\` and that \`card-sm\` is the chosen substitute. Updated Navbar JSDoc example.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Card, Tabs, Input, and Navbar to use daisyUI v5 styling class names (border and compact tokens updated) for consistent appearance.

* **Tests**
  * Updated test suites to verify components apply the new daisyUI v5 styling classes (Tabs variants and Card/Input style expectations adjusted).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/react/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->