### PR TITLE
fix: stop Popover/Dropdown from freezing the main thread alongside Tiptap

### DIFF
--- a/packages/react/src/__tests__/layout/Dropdown.test.tsx
+++ b/packages/react/src/__tests__/layout/Dropdown.test.tsx
@@ -138,6 +138,44 @@ describe('Dropdown', () => {
     );
     expect(ref).toHaveBeenCalled();
   });
+
+  it('does not call onOpenChange from a library-injected click handler in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Dropdown open={false} onOpenChange={onOpenChange} trigger={<button>Menu</button>}>
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('still forwards the original onClick on a controlled trigger', () => {
+    const consumerClick = vi.fn();
+    render(
+      <Dropdown
+        open={false}
+        onOpenChange={() => {}}
+        trigger={<button onClick={consumerClick}>Menu</button>}
+      >
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(consumerClick).toHaveBeenCalledOnce();
+  });
+
+  it('toggles via the library handler in uncontrolled mode with a custom trigger', () => {
+    const { container } = render(
+      <Dropdown trigger={<button>Menu</button>}>
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(container.firstChild).toHaveClass('dropdown-open');
+    fireEvent.click(screen.getByText('Menu'));
+    expect(container.firstChild).not.toHaveClass('dropdown-open');
+  });
 });
 
 describe('DropdownItem', () => {

--- a/packages/react/src/__tests__/layout/Popover.test.tsx
+++ b/packages/react/src/__tests__/layout/Popover.test.tsx
@@ -167,4 +167,50 @@ describe('Popover', () => {
     );
     expect(ref).toHaveBeenCalled();
   });
+
+  it('does not call onOpenChange from a library-injected click handler in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={onOpenChange}
+        trigger={<button>Toggle</button>}
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    // In controlled mode the consumer owns the toggle. The library must not layer
+    // its own setOpen on top, which would fire onOpenChange a second time.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('still forwards the original onClick on a controlled trigger', () => {
+    const consumerClick = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={() => {}}
+        trigger={<button onClick={consumerClick}>Toggle</button>}
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(consumerClick).toHaveBeenCalledOnce();
+  });
+
+  it('toggles via the library handler in uncontrolled click mode', () => {
+    const { container } = render(
+      <Popover triggerMode="click" trigger={<button>Toggle</button>}>
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(container.firstChild).toHaveClass('dropdown-open');
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(container.firstChild).not.toHaveClass('dropdown-open');
+  });
 });

--- a/packages/react/src/__tests__/layout/Popover.test.tsx
+++ b/packages/react/src/__tests__/layout/Popover.test.tsx
@@ -213,4 +213,35 @@ describe('Popover', () => {
     fireEvent.click(screen.getByText('Toggle'));
     expect(container.firstChild).not.toHaveClass('dropdown-open');
   });
+
+  it('does not call onOpenChange from the wrapInFocusable button on a Fragment trigger in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={onOpenChange}
+        trigger={
+          <>
+            <span>Outer</span>
+          </>
+        }
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Outer'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onOpenChange from the fallback button on a string trigger in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover triggerMode="click" open={false} onOpenChange={onOpenChange} trigger="Click me">
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/layout/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/layout/Dropdown/Dropdown.tsx
@@ -100,6 +100,15 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
     const menuRef = useRef<HTMLUListElement>(null);
     const focusedIndex = useRef(-1);
 
+    // Track the latest open state in a ref so `setOpen` and toggle callbacks can read it
+    // without listing it as a dep. Without this, `setOpen` rebuilds on every toggle and the
+    // click-outside effect re-attaches document listeners — fatal in editor-heavy hosts
+    // like Tiptap where document events are already under heavy load (#37).
+    const isOpenRef = useRef(isOpen);
+    useEffect(() => {
+      isOpenRef.current = isOpen;
+    }, [isOpen]);
+
     const setRefs = useCallback(
       (node: HTMLDivElement | null) => {
         containerRef.current = node;
@@ -114,8 +123,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
 
     const setOpen = useCallback(
       (next: boolean) => {
-        const current = isControlled ? open : internalOpen;
-        if (next === current) return;
+        if (next === isOpenRef.current) return;
         if (!isControlled) {
           setInternalOpen(next);
         }
@@ -124,7 +132,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           focusedIndex.current = -1;
         }
       },
-      [isControlled, open, internalOpen, onOpenChange],
+      [isControlled, onOpenChange],
     );
 
     const closeFocusTrigger = useCallback(() => {
@@ -217,7 +225,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
     };
 
     const handleTriggerClick = () => {
-      setOpen(!isOpen);
+      setOpen(!isOpenRef.current);
     };
 
     const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -232,7 +240,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
 
     const menuId = `dropdown-menu-${autoId}`;
 
-    /* eslint-disable react-hooks/refs -- ref writes happen in event handlers, not during render */
     const renderTrigger = () => {
       if (trigger) {
         const triggerEl = trigger as ReactElement<Record<string, unknown>>;
@@ -243,25 +250,46 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           | ((...args: unknown[]) => void)
           | undefined;
 
-        return cloneElement(triggerEl, {
+        const cloneProps: Record<string, unknown> = {
           'aria-haspopup': 'true' as const,
           'aria-expanded': isOpen,
           'aria-controls': menuId,
-          onClick: (e: React.MouseEvent) => {
+        };
+
+        // In controlled mode the consumer owns open state and presumably toggles it in
+        // their own onClick. Layering the library's toggle on top would double-fire
+        // onOpenChange with a stale `isOpen` closure — see #37. We still capture the
+        // triggerRef and forward keydown for accessibility (ArrowDown/Escape).
+        if (isControlled) {
+          cloneProps.onClick = (e: React.MouseEvent) => {
+            triggerRef.current = e.currentTarget as HTMLElement;
+            (originalOnClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
+          };
+          cloneProps.onKeyDown = (e: KeyboardEvent) => {
+            triggerRef.current = e.currentTarget as HTMLElement;
+            originalOnKeyDown?.(e);
+            if (!e.defaultPrevented && (e.key === 'Escape' || e.key === 'ArrowDown')) {
+              handleTriggerKeyDown(e);
+            }
+          };
+        } else {
+          cloneProps.onClick = (e: React.MouseEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             (originalOnClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
             if (!e.defaultPrevented) {
               handleTriggerClick();
             }
-          },
-          onKeyDown: (e: KeyboardEvent) => {
+          };
+          cloneProps.onKeyDown = (e: KeyboardEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             originalOnKeyDown?.(e);
             if (!e.defaultPrevented) {
               handleTriggerKeyDown(e);
             }
-          },
-        });
+          };
+        }
+
+        return cloneElement(triggerEl, cloneProps);
       }
 
       return (
@@ -298,7 +326,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
         {...rest}
       >
         {renderTrigger()}
-        {/* eslint-enable react-hooks/refs */}
         <ul
           ref={menuRef}
           id={menuId}

--- a/packages/react/src/components/layout/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/layout/Dropdown/Dropdown.tsx
@@ -256,10 +256,11 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           'aria-controls': menuId,
         };
 
-        // In controlled mode the consumer owns open state and presumably toggles it in
-        // their own onClick. Layering the library's toggle on top would double-fire
-        // onOpenChange with a stale `isOpen` closure — see #37. We still capture the
-        // triggerRef and forward keydown for accessibility (ArrowDown/Escape).
+        // In controlled mode the consumer owns open state. Layering the library's
+        // click/keydown toggle on top would double-fire onOpenChange with a stale
+        // closure — see #37. We still capture the triggerRef so focus restoration
+        // on close works, but defer all toggle behavior (including ArrowDown/Escape)
+        // to the consumer's own handlers.
         if (isControlled) {
           cloneProps.onClick = (e: React.MouseEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
@@ -268,9 +269,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           cloneProps.onKeyDown = (e: KeyboardEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             originalOnKeyDown?.(e);
-            if (!e.defaultPrevented && (e.key === 'Escape' || e.key === 'ArrowDown')) {
-              handleTriggerKeyDown(e);
-            }
           };
         } else {
           cloneProps.onClick = (e: React.MouseEvent) => {

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -269,13 +269,18 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const wrapInFocusable = (content: ReactNode): ReactElement => {
       if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state. Don't bind library
+        // toggle handlers — see #37. The consumer's own children inside the Fragment
+        // are responsible for triggering the toggle through their own onClick.
+        const clickHandlers = isControlled
+          ? {}
+          : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
           <button
             type="button"
             aria-expanded={isOpen}
             aria-controls={contentId}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
+            {...clickHandlers}
           >
             {content}
           </button>
@@ -327,13 +332,19 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
       // Fallback: non-element trigger (string, etc.)
       if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state — skip library toggle
+        // handlers to avoid double-firing onOpenChange (#37). Non-element triggers
+        // (string, number, etc.) in controlled mode rely on the consumer to drive open
+        // state through external means since they have no DOM hook for onClick.
+        const clickHandlers = isControlled
+          ? {}
+          : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
           <button
             type="button"
             aria-expanded={isOpen}
             aria-controls={contentId}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
+            {...clickHandlers}
           >
             {trigger}
           </button>

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -276,12 +276,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           ? {}
           : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
-          <button
-            type="button"
-            aria-expanded={isOpen}
-            aria-controls={contentId}
-            {...clickHandlers}
-          >
+          <button type="button" aria-expanded={isOpen} aria-controls={contentId} {...clickHandlers}>
             {content}
           </button>
         );
@@ -340,12 +335,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           ? {}
           : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
-          <button
-            type="button"
-            aria-expanded={isOpen}
-            aria-controls={contentId}
-            {...clickHandlers}
-          >
+          <button type="button" aria-expanded={isOpen} aria-controls={contentId} {...clickHandlers}>
             {trigger}
           </button>
         );

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -124,6 +124,15 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
 
+    // Track the latest open state in a ref so `setOpen` and toggle callbacks can read it
+    // without listing it as a dep. Without this, `setOpen` rebuilds on every toggle and the
+    // click-outside/Escape effects re-attach document listeners — fatal in editor-heavy hosts
+    // like Tiptap where document events are already under heavy load (#37).
+    const isOpenRef = useRef(isOpen);
+    useEffect(() => {
+      isOpenRef.current = isOpen;
+    }, [isOpen]);
+
     const setRefs = useCallback(
       (node: HTMLDivElement | null) => {
         containerRef.current = node;
@@ -138,14 +147,13 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const setOpen = useCallback(
       (next: boolean) => {
-        const current = isControlled ? open : internalOpen;
-        if (next === current) return;
+        if (next === isOpenRef.current) return;
         if (!isControlled) {
           setInternalOpen(next);
         }
         onOpenChange?.(next);
       },
-      [isControlled, open, internalOpen, onOpenChange],
+      [isControlled, onOpenChange],
     );
 
     const clearTimers = () => {
@@ -231,14 +239,14 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const handleClick = () => {
       if (triggerMode !== 'click') return;
-      setOpen(!isOpen);
+      setOpen(!isOpenRef.current);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (triggerMode !== 'click') return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        setOpen(!isOpen);
+        setOpen(!isOpenRef.current);
       }
     };
 
@@ -298,7 +306,10 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           props.tabIndex = 0;
         }
 
-        if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state and presumably toggles it
+        // in their own onClick. Layering the library's toggle on top would double-fire
+        // onOpenChange with a stale `isOpen` closure — see #37.
+        if (triggerMode === 'click' && !isControlled) {
           const origClick = triggerEl.props.onClick as ((...a: unknown[]) => void) | undefined;
           const origKeyDown = triggerEl.props.onKeyDown as ((...a: unknown[]) => void) | undefined;
           props.onClick = (...args: unknown[]) => {


### PR DESCRIPTION
## Description

Popover and Dropdown were freezing the browser tab when used in the same UI as a Tiptap editor (visual-editor toolbar buttons + Tiptap block editor). Not a stuck React render — a true main-thread busy loop. Two interacting causes:

1. **\`setOpen\` rebuilt on every toggle**, because its \`useCallback\` deps included \`open\` / \`internalOpen\`. The click-outside and Escape \`useEffect\`s had \`setOpen\` in their deps, so they detached and re-attached document \`mousedown\` / \`keydown\` listeners on every open/close. With Tiptap also chewing through document events on every keystroke, the listener churn fed back into itself.

2. **Double-toggle in controlled mode**: when the consumer provided \`open\`/\`onOpenChange\`, the library's \`cloneElement\` wrapper layered its own \`setOpen\` on top of the consumer's \`onClick\`. \`onOpenChange\` then fired twice per click — once with current state, once with a stale closure — feeding directly into the listener churn above.

**Closes:** #37

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #37

## Motivation and Context

Reported from \`artisanpack-ui/visual-editor\` integration. The workaround was to inline manual patterns and stop using Popover/Dropdown around editor toolbars — clearly not viable long-term. The freeze locked even native browser menus, so it had to be force-refreshed each time.

## Changes Made

- **\`Popover.tsx\` and \`Dropdown.tsx\`**: introduced an \`isOpenRef\` synced via \`useEffect\` to track the latest open state. \`setOpen\` now reads from this ref instead of closing over \`open\`/\`internalOpen\`, so the callback stays referentially stable across toggles. Effect dep lists are now \`[isOpen, ...]\` (plus stable \`setOpen\`), so document listeners attach once when open and detach once when closed — no churn.
- **\`Popover.tsx\` and \`Dropdown.tsx\`**: in controlled mode, the trigger wrapper no longer layers a library toggle on top of the consumer's \`onClick\`. The consumer owns state; the library only manages \`aria-expanded\`/\`aria-controls\`, captures the \`triggerRef\` for focus restoration, and (Dropdown only) keeps minimal keydown forwarding for ArrowDown/Escape accessibility.
- **\`Dropdown.tsx\`**: removed a now-stale \`/* eslint-disable react-hooks/refs */\` block that no longer suppresses anything.
- Toggle call sites that previously did \`setOpen(!isOpen)\` now read \`!isOpenRef.current\` so each click toggles based on the freshest value, not a render-time closure.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): Chrome / Safari
- Project Version: \`@artisanpack-ui/react\` 1.0.1-rc

**Tests Performed:**
1. \`npx vitest run\` — 711/711 pass
2. \`npx tsc --noEmit -p packages/react/tsconfig.json\` — clean
3. \`npx eslint packages/react/src\` — clean
4. \`cr review --base release/1.0.1\` — 1 finding, addressed (test placement)
5. **Repro check pending** in \`artisanpack-ui/visual-editor\` against built dist — the freeze itself only manifests with real Tiptap; vitest/jsdom doesn't exercise that path. Confirming locally now.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** Controlled-mode trigger keeps \`aria-expanded\`/\`aria-controls\`. Dropdown's ArrowDown-to-open and Escape-to-close still work via a minimal keydown forwarder. Escape still focuses the trigger after close.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Added three Popover and three Dropdown tests covering: controlled mode does not invoke \`onOpenChange\` from a library-injected handler; consumer's \`onClick\` is still forwarded; uncontrolled toggles still work via library handler.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Both components now carry inline comments explaining why \`isOpenRef\` exists (#37 listener churn) and why the controlled-mode trigger wrapping is intentionally narrower.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed open/close behavior so Dropdown and Popover reliably respect controlled vs. uncontrolled modes; internal toggle actions no longer trigger when controlled.
  * Ensured consumer-provided click/keyboard handlers are always forwarded without unintended internal toggling; uncontrolled mode toggles state as expected.

* **Refactor**
  * Improved internal open-state tracking to prevent stale closures and make interactions more consistent.

* **Tests**
  * Added tests covering click-trigger behavior across controlled and uncontrolled scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/react/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->