### PR TITLE
fix: import @artisanpack-ui/react from narrow subpaths in react-laravel

### DIFF
--- a/packages/react-laravel/src/__tests__/feedback/InertiaToastProvider.test.tsx
+++ b/packages/react-laravel/src/__tests__/feedback/InertiaToastProvider.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@inertiajs/react', () => ({
   usePage: () => mockUsePage(),
 }));
 
-vi.mock('@artisanpack-ui/react', () => ({
+vi.mock('@artisanpack-ui/react/feedback', () => ({
   ToastProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="toast-provider">{children}</div>
   ),

--- a/packages/react-laravel/src/feedback/InertiaToastProvider.tsx
+++ b/packages/react-laravel/src/feedback/InertiaToastProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ToastProvider, type ToastProviderProps } from '@artisanpack-ui/react';
+import { ToastProvider, type ToastProviderProps } from '@artisanpack-ui/react/feedback';
 import { useFlashMessages } from './useFlashMessages';
 
 /**

--- a/packages/react-laravel/src/feedback/useFlashMessages.ts
+++ b/packages/react-laravel/src/feedback/useFlashMessages.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { usePage } from '@inertiajs/react';
-import { useToast, type ToastAPI } from '@artisanpack-ui/react';
+import { useToast, type ToastAPI } from '@artisanpack-ui/react/feedback';
 import type { FlashMessages, SharedPageProps } from '../types';
 
 /**

--- a/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
+++ b/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Link } from '@inertiajs/react';
-import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react';
+import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react/navigation';
 
 /**
  * Breadcrumb item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
+++ b/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
@@ -1,6 +1,10 @@
 import { forwardRef, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Link } from '@inertiajs/react';
-import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react/navigation';
+import {
+  Breadcrumbs,
+  type BreadcrumbsProps,
+  type BreadcrumbItem,
+} from '@artisanpack-ui/react/navigation';
 
 /**
  * Breadcrumb item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaMenu.tsx
+++ b/packages/react-laravel/src/navigation/InertiaMenu.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useMemo, type ReactElement } from 'react';
 import { Link } from '@inertiajs/react';
-import { Menu, type MenuProps, type MenuItemType } from '@artisanpack-ui/react';
+import { Menu, type MenuProps, type MenuItemType } from '@artisanpack-ui/react/navigation';
 
 /**
  * Menu item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaPagination.tsx
+++ b/packages/react-laravel/src/navigation/InertiaPagination.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useCallback, useMemo } from 'react';
 import { router } from '@inertiajs/react';
-import { Pagination, type PaginationProps } from '@artisanpack-ui/react';
+import { Pagination, type PaginationProps } from '@artisanpack-ui/react/navigation';
 import type { LaravelPaginator } from '../types';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,13 @@
     "paths": {
       "@artisanpack-ui/tokens": ["./packages/tokens/src"],
       "@artisanpack-ui/react": ["./packages/react/src"],
+      "@artisanpack-ui/react/form": ["./packages/react/src/components/form"],
+      "@artisanpack-ui/react/layout": ["./packages/react/src/components/layout"],
+      "@artisanpack-ui/react/navigation": ["./packages/react/src/components/navigation"],
+      "@artisanpack-ui/react/data": ["./packages/react/src/components/data"],
+      "@artisanpack-ui/react/chart": ["./packages/react/src/components/data/Chart/Chart"],
+      "@artisanpack-ui/react/feedback": ["./packages/react/src/components/feedback"],
+      "@artisanpack-ui/react/utility": ["./packages/react/src/components/utility"],
       "@artisanpack-ui/react-laravel": ["./packages/react-laravel/src"]
     }
   },


### PR DESCRIPTION
## Description

The adapter's source files imported \`ToastProvider\`, \`useToast\`, \`Menu\`, \`Breadcrumbs\`, and \`Pagination\` from the root barrel of \`@artisanpack-ui/react\`. The published dist preserved those root imports, so any consumer doing \`import { InertiaToastProvider } from '@artisanpack-ui/react-laravel/feedback'\` transitively pulled the root barrel — which imports \`Chart\` and its optional peer \`react-apexcharts\`. Apps that don't use charts and didn't install \`react-apexcharts\` failed to build:

\`\`\`
Could not resolve "react-apexcharts" imported by "@artisanpack-ui/react"
\`\`\`

Bundles also pulled in the chart code unnecessarily (~92 KB of extra layout chunk on a real Laravel app, per the reporter's measurement).

**Closes:** #38

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #38

## Motivation and Context

Discovered while building a fresh Laravel/Vite project with the adapter but without \`react-apexcharts\` installed. The starter-kit workaround was an inlined local \`InertiaToastProvider\` importing from the \`@artisanpack-ui/react/feedback\` subpath directly. This PR fixes it at the source.

## Changes Made

- \`packages/react-laravel/src/feedback/InertiaToastProvider.tsx\`: import \`ToastProvider\` from \`@artisanpack-ui/react/feedback\`.
- \`packages/react-laravel/src/feedback/useFlashMessages.ts\`: import \`useToast\` from \`@artisanpack-ui/react/feedback\`.
- \`packages/react-laravel/src/navigation/InertiaMenu.tsx\`: import \`Menu\` from \`@artisanpack-ui/react/navigation\`.
- \`packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx\`: import \`Breadcrumbs\` from \`@artisanpack-ui/react/navigation\`.
- \`packages/react-laravel/src/navigation/InertiaPagination.tsx\`: import \`Pagination\` from \`@artisanpack-ui/react/navigation\`.
- \`packages/react-laravel/src/__tests__/feedback/InertiaToastProvider.test.tsx\`: updated the \`vi.mock\` module ID to match the new subpath.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): n/a (build-time issue)
- Project Version: \`@artisanpack-ui/react-laravel\` 1.0.1-rc

**Tests Performed:**
1. \`npx vitest run\` (react-laravel) — 56/56 pass
2. \`npx tsc --noEmit -p packages/react-laravel/tsconfig.json\` — clean
3. \`npx eslint packages/react-laravel/src\` — clean
4. \`cr review --base release/1.0.1\` — 0 findings
5. \`npm run build --workspace packages/react-laravel\` — clean; verified \`grep -E 'from "@artisanpack-ui/react"' packages/react-laravel/dist/*.mjs\` returns nothing and \`grep -E 'from "@artisanpack-ui/react/' packages/react-laravel/dist/*.mjs\` shows only the new narrow imports.

## Accessibility Tests Run

- [ ] Keyboard navigation tested (no runtime change)
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Build-time import change only. Component behavior is unchanged.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Updated existing \`vi.mock('@artisanpack-ui/react', ...)\` to mock the new subpath \`@artisanpack-ui/react/feedback\` so the 5 \`InertiaToastProvider\` tests continue to exercise the same provider/toast behavior.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** No new public surface; the change is internal to the adapter's dependency wiring.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized internal component imports and path aliases to improve modular structure and maintainability.
  * Updated TypeScript path mappings to reflect the new module layout.

* **Tests**
  * Updated test mocks to align with the reorganized modules.

No user-facing behavior or public APIs were changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/react/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->