### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-25
+
+### Fixed
+
+- **`@artisanpack-ui/react` — Single-control form components rendered with `<fieldset>`/`<legend>`** ([#39](https://github.com/ArtisanPack-UI/react/issues/39), [#40](https://github.com/ArtisanPack-UI/react/pull/40)). `Input`, `Textarea`, `Password`, `Pin`, `DatePicker`, `Select`, `RichTextEditor`, `Editor`, `File`, `ColorPicker`, and `Range` now render daisyUI v5's `fieldset` utility classes on plain `<div>`/`<label>` elements instead of the `<fieldset>`/`<legend>` HTML elements. Screen readers no longer announce a lone input as a "group". `<fieldset>`/`<legend>` are reserved for genuine control groups (`Radio`, `Checkbox` group, `Toggle`). Inline-label mode on `Input`, `Password`, and `DatePicker` switched to daisyUI v5's `floating-label` pattern. `RichTextEditor` now uses `aria-labelledby` for its `contenteditable` region.
+- **`@artisanpack-ui/react` — Keyboard-inaccessible action buttons** ([#40](https://github.com/ArtisanPack-UI/react/pull/40)). Removed `tabIndex={-1}` from the `Input` clear button and the `Password` clear/visibility-toggle buttons so they can be reached with the keyboard.
+- **`@artisanpack-ui/react` — `Tabs` and `Card` variants emitted dead daisyUI v4 class names** ([#36](https://github.com/ArtisanPack-UI/react/issues/36), [#41](https://github.com/ArtisanPack-UI/react/pull/41)). `Tabs` `bordered`/`lifted`/`boxed` now map to `tabs-border`/`tabs-lift`/`tabs-box`. `Card` `bordered` maps to `card-border`; `compact` maps to `card-sm` (daisyUI v5 removed `card-compact`). Dropped the no-longer-needed `input-bordered` class from `Input` (v5 inputs ship with a border by default).
+- **`@artisanpack-ui/react` — `Popover` and `Dropdown` froze the main thread alongside Tiptap** ([#37](https://github.com/ArtisanPack-UI/react/issues/37), [#42](https://github.com/ArtisanPack-UI/react/pull/42)). Stabilized `setOpen` with an `isOpenRef` so the click-outside and Escape effects no longer detach/re-attach document listeners on every toggle. In controlled mode the library no longer layers a second toggle on top of the consumer's `onClick`/`onKeyDown` — fixes the double-fire `onOpenChange` for cloned-element, Fragment, and string triggers.
+- **`@artisanpack-ui/react-laravel` — Adapter subpath imports transitively pulled the root barrel of `@artisanpack-ui/react`** ([#38](https://github.com/ArtisanPack-UI/react/issues/38), [#43](https://github.com/ArtisanPack-UI/react/pull/43)). `InertiaToastProvider`, `useFlashMessages`, `InertiaMenu`, `InertiaBreadcrumbs`, and `InertiaPagination` now import from narrow `@artisanpack-ui/react/feedback` and `@artisanpack-ui/react/navigation` subpaths so consumers don't have to install `react-apexcharts` when they're not using charts.
+
+### Changed
+
+- Added source-side TypeScript path mappings for every `@artisanpack-ui/react` subpath in the root `tsconfig.json` so the type-check job can resolve subpath imports without a prior `npm run build`.
+
+## [1.0.0] - 2026-03-31
+
 ### Added
 
 - `@artisanpack-ui/tokens` — Design tokens package with colors, spacing, typography, shadows, animations, borders, and glass morphism presets

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -895,7 +894,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,7 +942,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2841,7 +2838,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3006,7 +3004,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3370,7 +3367,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3769,7 +3765,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4214,7 +4209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4238,7 +4232,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4524,7 +4517,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "8.6.0",
@@ -4812,7 +4806,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4877,7 +4870,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6420,7 +6412,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6627,7 +6618,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6976,6 +6966,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7673,7 +7664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7742,7 +7732,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7759,6 +7748,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7774,6 +7764,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7786,7 +7777,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7854,7 +7846,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7944,7 +7935,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8597,7 +8587,6 @@
       "integrity": "sha512-tMoRAts9EVqf+mEMPLC6z1DPyHbcPe+CV1MhLN55IKsl0HxNjvVGK44rVPSePbltPE6vIsn4bdRj6CCUt8SJwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -9031,8 +9020,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -9146,7 +9134,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9445,7 +9432,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9610,7 +9596,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9704,7 +9689,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10112,7 +10096,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10132,7 +10115,7 @@
     },
     "packages/react": {
       "name": "@artisanpack-ui/react",
-      "version": "0.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/tokens": "*"
@@ -10169,7 +10152,7 @@
     },
     "packages/react-laravel": {
       "name": "@artisanpack-ui/react-laravel",
-      "version": "0.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/react": "*"
@@ -10415,7 +10398,6 @@
       "integrity": "sha512-PpuM4sJWy70sUh5U1IFn1m1p45MdHSChLUNnqEoUUUHSU2IHZugFrsVNhov1S8Q0cvfdrCRCvdBtHGSs6PSAWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@yr/monotone-cubic-spline": "^1.0.3",
         "svg.draggable.js": "^2.2.2",
@@ -10442,7 +10424,7 @@
     },
     "packages/tokens": {
       "name": "@artisanpack-ui/tokens",
-      "version": "0.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "clsx": "^2.1.1",

--- a/packages/react-laravel/CHANGELOG.md
+++ b/packages/react-laravel/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @artisanpack-ui/react-laravel
 
+## 1.0.1
+
+### Patch Changes
+
+- [#43](https://github.com/ArtisanPack-UI/react/pull/43) Import from narrow `@artisanpack-ui/react` subpaths in the adapter source ([#38](https://github.com/ArtisanPack-UI/react/issues/38)). `InertiaToastProvider`, `useFlashMessages`, `InertiaMenu`, `InertiaBreadcrumbs`, and `InertiaPagination` previously pulled the root barrel of `@artisanpack-ui/react`, which transitively dragged in the `Chart` component and its optional `react-apexcharts` peer. Apps doing subpath imports like `@artisanpack-ui/react-laravel/feedback` now stay clean — no more `Could not resolve "react-apexcharts"` build errors, and chart code is no longer pulled into bundles that don't use it.
+
+### Updated dependencies
+
+- `@artisanpack-ui/react@1.0.1`
+- `@artisanpack-ui/tokens@1.0.1`
+
 ## 1.0.0
 
 ### Major Changes
@@ -11,15 +22,3 @@
 - Updated dependencies [[`3669646`](https://github.com/ArtisanPack-UI/react/commit/3669646d2dfceb05478ba72e88046e25fad32f25)]:
   - @artisanpack-ui/tokens@1.0.0
   - @artisanpack-ui/react@1.0.0
-
-## 2.0.0
-
-### Major Changes
-
-- [#33](https://github.com/ArtisanPack-UI/react/pull/33) [`0ff7c1c`](https://github.com/ArtisanPack-UI/react/commit/0ff7c1c9aaad9b15be04563d450957f9fc1b80e2) Thanks [@ViewFromTheBox](https://github.com/ViewFromTheBox)! - Initial release
-
-### Patch Changes
-
-- Updated dependencies [[`0ff7c1c`](https://github.com/ArtisanPack-UI/react/commit/0ff7c1c9aaad9b15be04563d450957f9fc1b80e2)]:
-  - @artisanpack-ui/tokens@2.0.0
-  - @artisanpack-ui/react@2.0.0

--- a/packages/react-laravel/package.json
+++ b/packages/react-laravel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/react-laravel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Inertia.js adapter wrappers for ArtisanPack UI React components",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/react-laravel/src/__tests__/feedback/InertiaToastProvider.test.tsx
+++ b/packages/react-laravel/src/__tests__/feedback/InertiaToastProvider.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@inertiajs/react', () => ({
   usePage: () => mockUsePage(),
 }));
 
-vi.mock('@artisanpack-ui/react', () => ({
+vi.mock('@artisanpack-ui/react/feedback', () => ({
   ToastProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="toast-provider">{children}</div>
   ),

--- a/packages/react-laravel/src/feedback/InertiaToastProvider.tsx
+++ b/packages/react-laravel/src/feedback/InertiaToastProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ToastProvider, type ToastProviderProps } from '@artisanpack-ui/react';
+import { ToastProvider, type ToastProviderProps } from '@artisanpack-ui/react/feedback';
 import { useFlashMessages } from './useFlashMessages';
 
 /**

--- a/packages/react-laravel/src/feedback/useFlashMessages.ts
+++ b/packages/react-laravel/src/feedback/useFlashMessages.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { usePage } from '@inertiajs/react';
-import { useToast, type ToastAPI } from '@artisanpack-ui/react';
+import { useToast, type ToastAPI } from '@artisanpack-ui/react/feedback';
 import type { FlashMessages, SharedPageProps } from '../types';
 
 /**

--- a/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
+++ b/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Link } from '@inertiajs/react';
-import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react';
+import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react/navigation';
 
 /**
  * Breadcrumb item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
+++ b/packages/react-laravel/src/navigation/InertiaBreadcrumbs.tsx
@@ -1,6 +1,10 @@
 import { forwardRef, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Link } from '@inertiajs/react';
-import { Breadcrumbs, type BreadcrumbsProps, type BreadcrumbItem } from '@artisanpack-ui/react/navigation';
+import {
+  Breadcrumbs,
+  type BreadcrumbsProps,
+  type BreadcrumbItem,
+} from '@artisanpack-ui/react/navigation';
 
 /**
  * Breadcrumb item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaMenu.tsx
+++ b/packages/react-laravel/src/navigation/InertiaMenu.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useMemo, type ReactElement } from 'react';
 import { Link } from '@inertiajs/react';
-import { Menu, type MenuProps, type MenuItemType } from '@artisanpack-ui/react';
+import { Menu, type MenuProps, type MenuItemType } from '@artisanpack-ui/react/navigation';
 
 /**
  * Menu item descriptor with Inertia `href` support.

--- a/packages/react-laravel/src/navigation/InertiaPagination.tsx
+++ b/packages/react-laravel/src/navigation/InertiaPagination.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useCallback, useMemo } from 'react';
 import { router } from '@inertiajs/react';
-import { Pagination, type PaginationProps } from '@artisanpack-ui/react';
+import { Pagination, type PaginationProps } from '@artisanpack-ui/react/navigation';
 import type { LaravelPaginator } from '../types';
 
 /**

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @artisanpack-ui/react
 
+## 1.0.1
+
+### Patch Changes
+
+- [#40](https://github.com/ArtisanPack-UI/react/pull/40) Fix `<fieldset>`/`<legend>` wrapping single-control form components ([#39](https://github.com/ArtisanPack-UI/react/issues/39)). `Input`, `Textarea`, `Password`, `Pin`, `DatePicker`, `Select`, `RichTextEditor`, `Editor`, `File`, `ColorPicker`, and `Range` now use daisyUI v5 `fieldset` utility classes on plain `<div>`/`<label>` elements. `<fieldset>`/`<legend>` HTML elements are reserved for genuine control groups (`Radio`, `Checkbox` group, `Toggle`). Inline-label mode on `Input`, `Password`, and `DatePicker` switched to daisyUI v5's `floating-label` pattern. `RichTextEditor` now uses `aria-labelledby` for its `contenteditable` region.
+- [#40](https://github.com/ArtisanPack-UI/react/pull/40) Keep `Input` clear button and `Password` clear/visibility-toggle buttons in the keyboard tab order — removed `tabIndex={-1}` so they're reachable for keyboard users.
+- [#41](https://github.com/ArtisanPack-UI/react/pull/41) Replace dead daisyUI v4 class names with v5 equivalents ([#36](https://github.com/ArtisanPack-UI/react/issues/36)): `Tabs` variants `tabs-bordered`/`tabs-lifted`/`tabs-boxed` → `tabs-border`/`tabs-lift`/`tabs-box`; `Card` `bordered` → `card-border`, `compact` → `card-sm` (daisyUI v5 removed `card-compact`); dropped the redundant `input-bordered` class from `Input` (v5's `.input` includes the border by default).
+- [#42](https://github.com/ArtisanPack-UI/react/pull/42) Stop `Popover` and `Dropdown` from freezing the main thread when used alongside Tiptap ([#37](https://github.com/ArtisanPack-UI/react/issues/37)). `setOpen` is now referentially stable via an `isOpenRef`, so the click-outside and Escape effects no longer detach/re-attach document listeners on every toggle. In controlled mode the library no longer layers a second toggle on top of the consumer's `onClick`/`onKeyDown` — fixes the double-fire `onOpenChange` for cloned-element, Fragment, and string triggers.
+
+### Updated dependencies
+
+- `@artisanpack-ui/tokens@1.0.1`
+
 ## 1.0.0
 
 ### Major Changes
@@ -10,14 +23,3 @@
 
 - Updated dependencies [[`3669646`](https://github.com/ArtisanPack-UI/react/commit/3669646d2dfceb05478ba72e88046e25fad32f25)]:
   - @artisanpack-ui/tokens@1.0.0
-
-## 2.0.0
-
-### Major Changes
-
-- [#33](https://github.com/ArtisanPack-UI/react/pull/33) [`0ff7c1c`](https://github.com/ArtisanPack-UI/react/commit/0ff7c1c9aaad9b15be04563d450957f9fc1b80e2) Thanks [@ViewFromTheBox](https://github.com/ViewFromTheBox)! - Initial release
-
-### Patch Changes
-
-- Updated dependencies [[`0ff7c1c`](https://github.com/ArtisanPack-UI/react/commit/0ff7c1c9aaad9b15be04563d450957f9fc1b80e2)]:
-  - @artisanpack-ui/tokens@2.0.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "80+ React UI components for the ArtisanPack UI ecosystem, styled with DaisyUI and Tailwind CSS",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/react/src/__tests__/form/ColorPicker.test.tsx
+++ b/packages/react/src/__tests__/form/ColorPicker.test.tsx
@@ -8,6 +8,12 @@ describe('ColorPicker', () => {
     expect(screen.getByText('Brand Color')).toBeInTheDocument();
   });
 
+  it('does not wrap a single color input in a fieldset/legend', () => {
+    const { container } = render(<ColorPicker label="Brand Color" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
   it('renders color input', () => {
     render(<ColorPicker label="Color" />);
     const input = screen.getByLabelText('Color');

--- a/packages/react/src/__tests__/form/DatePicker.test.tsx
+++ b/packages/react/src/__tests__/form/DatePicker.test.tsx
@@ -8,6 +8,18 @@ describe('DatePicker', () => {
     expect(screen.getByText('Start Date')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<DatePicker label="Start Date" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<DatePicker id="start" label="Start Date" />);
+    const input = screen.getByLabelText('Start Date');
+    expect(input).toHaveAttribute('id', 'start');
+  });
+
   it('renders date input by default', () => {
     const { container } = render(<DatePicker label="Date" />);
     const input = container.querySelector('input[type="date"]');

--- a/packages/react/src/__tests__/form/Editor.test.tsx
+++ b/packages/react/src/__tests__/form/Editor.test.tsx
@@ -8,6 +8,18 @@ describe('Editor', () => {
     expect(screen.getByText('Code')).toBeInTheDocument();
   });
 
+  it('does not wrap a single textarea in a fieldset/legend', () => {
+    const { container } = render(<Editor label="Code" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the textarea via htmlFor/id', () => {
+    render(<Editor id="snippet" label="Code" />);
+    const textarea = screen.getByLabelText('Code');
+    expect(textarea).toHaveAttribute('id', 'snippet');
+  });
+
   it('renders textarea', () => {
     render(<Editor label="Code" />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/File.test.tsx
+++ b/packages/react/src/__tests__/form/File.test.tsx
@@ -8,6 +8,18 @@ describe('File', () => {
     expect(screen.getByText('Upload')).toBeInTheDocument();
   });
 
+  it('does not wrap a single file input in a fieldset/legend', () => {
+    const { container } = render(<File label="Upload" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('does not wrap a drag-drop file input in a fieldset/legend', () => {
+    const { container } = render(<File label="Upload" withDragDrop />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
   it('renders file input', () => {
     const { container } = render(<File label="Upload" />);
     const input = container.querySelector('input[type="file"]');

--- a/packages/react/src/__tests__/form/Input.test.tsx
+++ b/packages/react/src/__tests__/form/Input.test.tsx
@@ -94,6 +94,11 @@ describe('Input', () => {
     expect(onClear).toHaveBeenCalledOnce();
   });
 
+  it('keeps the clear button keyboard-focusable', () => {
+    render(<Input label="Search" clearable onClear={() => {}} />);
+    expect(screen.getByLabelText('Clear input')).not.toHaveAttribute('tabindex', '-1');
+  });
+
   it('renders inline label as a floating label associated with the input', () => {
     const { container } = render(<Input id="city" label="City" inline />);
     expect(container.querySelector('fieldset')).not.toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Input.test.tsx
+++ b/packages/react/src/__tests__/form/Input.test.tsx
@@ -8,6 +8,34 @@ describe('Input', () => {
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<Input label="Email" type="email" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<Input label="Email" type="email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input).toHaveAttribute('id');
+    expect(input.id).toBeTruthy();
+  });
+
+  it('renders the visible label with the daisyUI v5 fieldset-legend class', () => {
+    render(<Input id="email" label="Email" type="email" />);
+    const labelEl = screen.getByText('Email').closest('label');
+    expect(labelEl).toBeInTheDocument();
+    expect(labelEl).toHaveClass('fieldset-legend');
+    expect(labelEl).toHaveAttribute('for', 'email');
+  });
+
+  it('uses an explicit caller-provided id', () => {
+    render(<Input id="user-email" label="Email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('id', 'user-email');
+  });
+
   it('renders hint text', () => {
     render(<Input label="Email" hint="We will never share your email" />);
     expect(screen.getByText('We will never share your email')).toBeInTheDocument();
@@ -28,6 +56,18 @@ describe('Input', () => {
   it('sets aria-invalid when error is present', () => {
     render(<Input label="Email" error="Required" />);
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('wires aria-describedby to the hint when present', () => {
+    render(<Input id="phone" label="Phone" hint="Numbers only" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'phone-hint');
+  });
+
+  it('wires aria-describedby to the error when present', () => {
+    render(<Input id="phone" label="Phone" error="Required" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'phone-error');
   });
 
   it('shows required indicator', () => {
@@ -54,9 +94,29 @@ describe('Input', () => {
     expect(onClear).toHaveBeenCalledOnce();
   });
 
-  it('renders inline label', () => {
-    render(<Input label="Floating" inline />);
-    expect(screen.getByText('Floating')).toHaveClass('label');
+  it('renders inline label as a floating label associated with the input', () => {
+    const { container } = render(<Input id="city" label="City" inline />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+    const wrapper = container.querySelector('label.floating-label');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute('for', 'city');
+    const input = screen.getByLabelText('City');
+    expect(input).toHaveAttribute('id', 'city');
+    expect(wrapper?.contains(input)).toBe(true);
+    expect(input).toHaveAttribute('placeholder', ' ');
+  });
+
+  it('does not inject a single-space placeholder in non-inline mode', () => {
+    render(<Input id="city" label="City" />);
+    const input = screen.getByLabelText('City');
+    expect(input).not.toHaveAttribute('placeholder');
+  });
+
+  it('preserves a caller-provided placeholder in inline mode', () => {
+    render(<Input id="city" label="City" inline placeholder="Type a city" />);
+    const input = screen.getByLabelText('City');
+    expect(input).toHaveAttribute('placeholder', 'Type a city');
   });
 
   it('forwards ref', () => {

--- a/packages/react/src/__tests__/form/Password.test.tsx
+++ b/packages/react/src/__tests__/form/Password.test.tsx
@@ -8,6 +8,18 @@ describe('Password', () => {
     expect(screen.getByText('Password')).toBeInTheDocument();
   });
 
+  it('does not wrap a single input in a fieldset/legend', () => {
+    const { container } = render(<Password label="Password" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(<Password id="user-pw" label="Password" />);
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveAttribute('id', 'user-pw');
+  });
+
   it('renders as password type by default', () => {
     const { container } = render(<Password label="Password" />);
     const input = container.querySelector('input');

--- a/packages/react/src/__tests__/form/Password.test.tsx
+++ b/packages/react/src/__tests__/form/Password.test.tsx
@@ -45,6 +45,16 @@ describe('Password', () => {
     expect(screen.queryByLabelText('Show password')).not.toBeInTheDocument();
   });
 
+  it('keeps the visibility toggle keyboard-focusable', () => {
+    render(<Password label="Password" />);
+    expect(screen.getByLabelText('Show password')).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('keeps the clear button keyboard-focusable', () => {
+    render(<Password label="Password" clearable onClear={() => {}} />);
+    expect(screen.getByLabelText('Clear password')).not.toHaveAttribute('tabindex', '-1');
+  });
+
   it('renders error', () => {
     render(<Password label="Password" error="Too short" />);
     expect(screen.getByText('Too short')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Pin.test.tsx
+++ b/packages/react/src/__tests__/form/Pin.test.tsx
@@ -9,6 +9,13 @@ describe('Pin', () => {
     expect(inputs).toHaveLength(4);
   });
 
+  it('does not wrap inputs in a fieldset/legend', () => {
+    const { container } = render(<Pin length={4} />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+    expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'PIN input');
+  });
+
   it('renders 6 inputs', () => {
     render(<Pin length={6} />);
     const inputs = screen.getAllByRole('textbox');

--- a/packages/react/src/__tests__/form/Range.test.tsx
+++ b/packages/react/src/__tests__/form/Range.test.tsx
@@ -8,6 +8,18 @@ describe('Range', () => {
     expect(screen.getByText('Volume')).toBeInTheDocument();
   });
 
+  it('does not wrap a single slider in a fieldset/legend', () => {
+    const { container } = render(<Range label="Volume" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the slider via htmlFor/id', () => {
+    render(<Range id="vol" label="Volume" />);
+    const slider = screen.getByLabelText('Volume');
+    expect(slider).toHaveAttribute('id', 'vol');
+  });
+
   it('renders as range input', () => {
     render(<Range label="Volume" />);
     expect(screen.getByRole('slider')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/RichTextEditor.test.tsx
+++ b/packages/react/src/__tests__/form/RichTextEditor.test.tsx
@@ -8,6 +8,19 @@ describe('RichTextEditor', () => {
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
+  it('does not wrap the editor in a fieldset/legend', () => {
+    const { container } = render(<RichTextEditor label="Content" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the contenteditable region via aria-labelledby', () => {
+    render(<RichTextEditor id="content-editor" label="Content" />);
+    const editor = screen.getByLabelText('Content');
+    expect(editor).toHaveAttribute('id', 'content-editor');
+    expect(editor).toHaveAttribute('aria-labelledby', 'content-editor-label');
+  });
+
   it('renders contentEditable area', () => {
     render(<RichTextEditor label="Content" />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Select.test.tsx
+++ b/packages/react/src/__tests__/form/Select.test.tsx
@@ -14,6 +14,19 @@ describe('Select', () => {
     expect(screen.getByText('Country')).toBeInTheDocument();
   });
 
+  it('does not wrap a single select in a fieldset/legend', () => {
+    const { container } = render(<Select label="Country" options={options} />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the select via htmlFor/id', () => {
+    render(<Select id="country" label="Country" options={options} />);
+    const select = screen.getByLabelText('Country');
+    expect(select).toBeInstanceOf(HTMLSelectElement);
+    expect(select).toHaveAttribute('id', 'country');
+  });
+
   it('renders options', () => {
     render(<Select label="Country" options={options} />);
     expect(screen.getByText('Option 1')).toBeInTheDocument();

--- a/packages/react/src/__tests__/form/Textarea.test.tsx
+++ b/packages/react/src/__tests__/form/Textarea.test.tsx
@@ -8,6 +8,19 @@ describe('Textarea', () => {
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
+  it('does not wrap a single textarea in a fieldset/legend', () => {
+    const { container } = render(<Textarea label="Description" />);
+    expect(container.querySelector('fieldset')).not.toBeInTheDocument();
+    expect(container.querySelector('legend')).not.toBeInTheDocument();
+  });
+
+  it('associates the visible label with the textarea via htmlFor/id', () => {
+    render(<Textarea id="bio" label="Bio" />);
+    const textarea = screen.getByLabelText('Bio');
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+    expect(textarea).toHaveAttribute('id', 'bio');
+  });
+
   it('renders hint', () => {
     render(<Textarea label="Bio" hint="Max 500 characters" />);
     expect(screen.getByText('Max 500 characters')).toBeInTheDocument();

--- a/packages/react/src/__tests__/layout/Card.test.tsx
+++ b/packages/react/src/__tests__/layout/Card.test.tsx
@@ -57,14 +57,14 @@ describe('Card', () => {
     expect(container.firstChild).not.toHaveClass('shadow-xl');
   });
 
-  it('applies bordered class', () => {
+  it('applies bordered class (daisyUI v5 card-border)', () => {
     const { container } = render(<Card bordered>Content</Card>);
-    expect(container.firstChild).toHaveClass('card-bordered');
+    expect(container.firstChild).toHaveClass('card-border');
   });
 
-  it('applies compact class', () => {
+  it('applies compact class (daisyUI v5 card-sm)', () => {
     const { container } = render(<Card compact>Content</Card>);
-    expect(container.firstChild).toHaveClass('card-compact');
+    expect(container.firstChild).toHaveClass('card-sm');
   });
 
   it('applies glass effect', () => {

--- a/packages/react/src/__tests__/layout/Dropdown.test.tsx
+++ b/packages/react/src/__tests__/layout/Dropdown.test.tsx
@@ -138,6 +138,44 @@ describe('Dropdown', () => {
     );
     expect(ref).toHaveBeenCalled();
   });
+
+  it('does not call onOpenChange from a library-injected click handler in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Dropdown open={false} onOpenChange={onOpenChange} trigger={<button>Menu</button>}>
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('still forwards the original onClick on a controlled trigger', () => {
+    const consumerClick = vi.fn();
+    render(
+      <Dropdown
+        open={false}
+        onOpenChange={() => {}}
+        trigger={<button onClick={consumerClick}>Menu</button>}
+      >
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(consumerClick).toHaveBeenCalledOnce();
+  });
+
+  it('toggles via the library handler in uncontrolled mode with a custom trigger', () => {
+    const { container } = render(
+      <Dropdown trigger={<button>Menu</button>}>
+        <DropdownItem>Item</DropdownItem>
+      </Dropdown>,
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(container.firstChild).toHaveClass('dropdown-open');
+    fireEvent.click(screen.getByText('Menu'));
+    expect(container.firstChild).not.toHaveClass('dropdown-open');
+  });
 });
 
 describe('DropdownItem', () => {

--- a/packages/react/src/__tests__/layout/Popover.test.tsx
+++ b/packages/react/src/__tests__/layout/Popover.test.tsx
@@ -167,4 +167,50 @@ describe('Popover', () => {
     );
     expect(ref).toHaveBeenCalled();
   });
+
+  it('does not call onOpenChange from a library-injected click handler in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={onOpenChange}
+        trigger={<button>Toggle</button>}
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    // In controlled mode the consumer owns the toggle. The library must not layer
+    // its own setOpen on top, which would fire onOpenChange a second time.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('still forwards the original onClick on a controlled trigger', () => {
+    const consumerClick = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={() => {}}
+        trigger={<button onClick={consumerClick}>Toggle</button>}
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(consumerClick).toHaveBeenCalledOnce();
+  });
+
+  it('toggles via the library handler in uncontrolled click mode', () => {
+    const { container } = render(
+      <Popover triggerMode="click" trigger={<button>Toggle</button>}>
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(container.firstChild).toHaveClass('dropdown-open');
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(container.firstChild).not.toHaveClass('dropdown-open');
+  });
 });

--- a/packages/react/src/__tests__/layout/Popover.test.tsx
+++ b/packages/react/src/__tests__/layout/Popover.test.tsx
@@ -213,4 +213,35 @@ describe('Popover', () => {
     fireEvent.click(screen.getByText('Toggle'));
     expect(container.firstChild).not.toHaveClass('dropdown-open');
   });
+
+  it('does not call onOpenChange from the wrapInFocusable button on a Fragment trigger in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover
+        triggerMode="click"
+        open={false}
+        onOpenChange={onOpenChange}
+        trigger={
+          <>
+            <span>Outer</span>
+          </>
+        }
+      >
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Outer'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onOpenChange from the fallback button on a string trigger in controlled mode (#37)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Popover triggerMode="click" open={false} onOpenChange={onOpenChange} trigger="Click me">
+        Content
+      </Popover>,
+    );
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/__tests__/layout/Tabs.test.tsx
+++ b/packages/react/src/__tests__/layout/Tabs.test.tsx
@@ -79,9 +79,19 @@ describe('Tabs', () => {
     expect(onChange).toHaveBeenCalledWith('tab2');
   });
 
-  it('applies variant class', () => {
+  it('applies variant class (daisyUI v5 naming)', () => {
     render(<Tabs tabs={sampleTabs} variant="lifted" />);
-    expect(screen.getByRole('tablist')).toHaveClass('tabs-lifted');
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-lift');
+  });
+
+  it('maps boxed variant to daisyUI v5 tabs-box', () => {
+    render(<Tabs tabs={sampleTabs} variant="boxed" />);
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-box');
+  });
+
+  it('maps bordered variant to daisyUI v5 tabs-border', () => {
+    render(<Tabs tabs={sampleTabs} variant="bordered" />);
+    expect(screen.getByRole('tablist')).toHaveClass('tabs-border');
   });
 
   it('applies size class', () => {

--- a/packages/react/src/components/form/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/form/ColorPicker/ColorPicker.tsx
@@ -129,16 +129,15 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
     }, [onRandomColor]);
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label
+        <span
           className={cn('input w-full', error && 'input-error', className)}
-          htmlFor={id}
           style={{ paddingInlineStart: 0, overflow: 'hidden' }}
         >
           <input
@@ -221,7 +220,7 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
               {iconRight}
             </span>
           )}
-        </label>
+        </span>
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -232,7 +231,7 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/form/DatePicker/DatePicker.tsx
@@ -71,55 +71,76 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     const errorId = error ? `${id}-error` : undefined;
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
-    const hasAdornments = icon || iconRight || inline;
+    const hasAdornments = icon || iconRight;
+
+    const commonInputProps = {
+      ref,
+      id,
+      type: dateType,
+      'aria-invalid': error ? true : undefined,
+      'aria-describedby': describedBy,
+      'aria-required': required || undefined,
+      required,
+      // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+      // floating-label CSS positions/animates the label correctly without showing visible text.
+      placeholder: rest.placeholder ?? (inline && label ? ' ' : undefined),
+      ...rest,
+    } as const;
+
+    const dateInput = hasAdornments ? (
+      <span className={cn('input w-full', error && 'input-error', className)}>
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <input className="grow" style={{ height: 'auto' }} {...commonInputProps} />
+        {iconRight && (
+          <span className="opacity-50" aria-hidden="true">
+            {iconRight}
+          </span>
+        )}
+      </span>
+    ) : (
+      <input
+        className={cn('input w-full', error && 'input-error', className)}
+        {...commonInputProps}
+      />
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {dateInput}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
 
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
-        )}
-        {hasAdornments ? (
-          <label className={cn('input w-full', error && 'input-error', className)} htmlFor={id}>
-            {icon && (
-              <span className="opacity-50" aria-hidden="true">
-                {icon}
-              </span>
-            )}
-            <input
-              ref={ref}
-              id={id}
-              type={dateType}
-              className="grow"
-              style={{ height: 'auto' }}
-              aria-invalid={error ? true : undefined}
-              aria-describedby={describedBy}
-              aria-required={required || undefined}
-              required={required}
-              {...rest}
-            />
-            {inline && label && <span className="label">{label}</span>}
-            {iconRight && (
-              <span className="opacity-50" aria-hidden="true">
-                {iconRight}
-              </span>
-            )}
           </label>
-        ) : (
-          <input
-            ref={ref}
-            id={id}
-            type={dateType}
-            className={cn('input w-full', error && 'input-error', className)}
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
         )}
+        {dateInput}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -130,7 +151,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Editor/Editor.tsx
+++ b/packages/react/src/components/form/Editor/Editor.tsx
@@ -44,14 +44,12 @@ export const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
-            <label htmlFor={id}>
-              {label}
-              {required && <span className="text-error ml-1">*</span>}
-            </label>
-          </legend>
+          <label htmlFor={id} className="fieldset-legend">
+            {label}
+            {required && <span className="text-error ml-1">*</span>}
+          </label>
         )}
         <textarea
           ref={ref}
@@ -74,7 +72,7 @@ export const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/File/File.tsx
+++ b/packages/react/src/components/form/File/File.tsx
@@ -129,12 +129,12 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
 
     if (withDragDrop) {
       return (
-        <fieldset className="fieldset">
+        <div className="fieldset w-full">
           {label && (
-            <legend className="fieldset-legend">
+            <label htmlFor={id} className="fieldset-legend">
               {label}
               {required && <span className="text-error ml-1">*</span>}
-            </legend>
+            </label>
           )}
           <div
             className={cn(
@@ -188,17 +188,17 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
               {error}
             </p>
           )}
-        </fieldset>
+        </div>
       );
     }
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <input
           ref={setRefs}
@@ -229,7 +229,7 @@ export const File = forwardRef<HTMLInputElement, FileProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -92,7 +92,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         className={cn(
           'input',
           'w-full',
-          (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
           error && 'input-error',
           className,
         )}

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -131,7 +131,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={onClear}
             aria-label="Clear input"
-            tabIndex={-1}
           >
             ✕
           </button>

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -88,14 +88,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     const inputBox = (
-      <span
-        className={cn(
-          'input',
-          'w-full',
-          error && 'input-error',
-          className,
-        )}
-      >
+      <span className={cn('input', 'w-full', error && 'input-error', className)}>
         {icon && (
           <span className="opacity-50" aria-hidden="true">
             {icon}

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -29,14 +29,20 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
   clearable?: boolean;
   /** Callback fired when the clear button is clicked. Use this to reset the input value. */
   onClear?: () => void;
-  /** When true, renders the label as a floating/inline label inside the input wrapper. @defaultValue `false` */
+  /** When true, renders the label as a floating label using daisyUI's `floating-label` pattern. @defaultValue `false` */
   inline?: boolean;
 }
 
 /**
- * A text input component with DaisyUI styling, supporting labels, hint/error text,
+ * A text input component with daisyUI v5 styling, supporting labels, hint/error text,
  * left/right icons, prefix/suffix adornments, a clearable action button, and
- * an inline (floating) label mode. Automatically generates accessible IDs and ARIA attributes.
+ * a floating label mode. Automatically generates accessible IDs and ARIA attributes.
+ *
+ * Renders the canonical accessible pattern for a single labeled input: a `<label htmlFor>`
+ * paired with the `<input id>`. The visible label and helper text use daisyUI v5's
+ * `.fieldset`, `.fieldset-legend`, and `.fieldset-label` utility classes on plain
+ * elements — `<fieldset>`/`<legend>` HTML elements are reserved for groups of related
+ * controls (e.g. radio/checkbox groups) and are intentionally not used here.
  *
  * @example
  * ```tsx
@@ -81,67 +87,96 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const errorId = error ? `${id}-error` : undefined;
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
+    const inputBox = (
+      <span
+        className={cn(
+          'input',
+          'w-full',
+          (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
+          error && 'input-error',
+          className,
+        )}
+      >
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        {prefix && (
+          <span className="opacity-50" aria-hidden="true">
+            {prefix}
+          </span>
+        )}
+        <input
+          ref={ref}
+          id={id}
+          className="grow"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          required={required}
+          // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+          // floating-label CSS positions/animates the label correctly without showing visible text.
+          placeholder={rest.placeholder ?? (inline && label ? ' ' : undefined)}
+          {...rest}
+        />
+        {suffix && (
+          <span className="opacity-50" aria-hidden="true">
+            {suffix}
+          </span>
+        )}
+        {clearable && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={onClear}
+            aria-label="Clear input"
+            tabIndex={-1}
+          >
+            ✕
+          </button>
+        )}
+        {iconRight && (
+          <span className="opacity-50" aria-hidden="true">
+            {iconRight}
+          </span>
+        )}
+      </span>
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {inputBox}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
+
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label
-          className={cn(
-            'input',
-            'w-full',
-            (icon || iconRight || prefix || suffix || clearable) && 'input-bordered',
-            error && 'input-error',
-            className,
-          )}
-          htmlFor={id}
-        >
-          {icon && (
-            <span className="opacity-50" aria-hidden="true">
-              {icon}
-            </span>
-          )}
-          {prefix && (
-            <span className="opacity-50" aria-hidden="true">
-              {prefix}
-            </span>
-          )}
-          <input
-            ref={ref}
-            id={id}
-            className="grow"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
-          {inline && label && <span className="label">{label}</span>}
-          {suffix && (
-            <span className="opacity-50" aria-hidden="true">
-              {suffix}
-            </span>
-          )}
-          {clearable && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={onClear}
-              aria-label="Clear input"
-              tabIndex={-1}
-            >
-              ✕
-            </button>
-          )}
-          {iconRight && (
-            <span className="opacity-50" aria-hidden="true">
-              {iconRight}
-            </span>
-          )}
-        </label>
+        {inputBox}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -152,7 +187,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Password/Password.tsx
+++ b/packages/react/src/components/form/Password/Password.tsx
@@ -106,55 +106,85 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
 
     const [visible, setVisible] = useState(false);
 
+    const passwordBox = (
+      <span className={cn('input w-full', error && 'input-error', className)}>
+        {icon && (
+          <span className="opacity-50" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <input
+          ref={ref}
+          id={id}
+          type={visible ? 'text' : 'password'}
+          className="grow"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          required={required}
+          // In inline mode, a single-space placeholder triggers :placeholder-shown so daisyUI's
+          // floating-label CSS positions/animates the label correctly without showing visible text.
+          placeholder={rest.placeholder ?? (inline && label ? ' ' : undefined)}
+          {...rest}
+        />
+        {clearable && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={onClear}
+            aria-label="Clear password"
+            tabIndex={-1}
+          >
+            ✕
+          </button>
+        )}
+        {!hideToggle && (
+          <button
+            type="button"
+            className="opacity-50 hover:opacity-100 cursor-pointer"
+            onClick={() => setVisible((v) => !v)}
+            aria-label={visible ? 'Hide password' : 'Show password'}
+            tabIndex={-1}
+          >
+            {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
+          </button>
+        )}
+      </span>
+    );
+
+    if (inline && label) {
+      return (
+        <div className="fieldset w-full">
+          <label htmlFor={id} className="floating-label w-full">
+            <span>
+              {label}
+              {required && <span className="text-error ml-1">*</span>}
+            </span>
+            {passwordBox}
+          </label>
+          {hint && !error && (
+            <p id={hintId} className="fieldset-label">
+              {hint}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="fieldset-label text-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      );
+    }
+
     return (
-      <fieldset className="fieldset">
-        {label && !inline && (
-          <legend className="fieldset-legend">
+      <div className="fieldset w-full">
+        {label && (
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label className={cn('input w-full', error && 'input-error', className)} htmlFor={id}>
-          {icon && (
-            <span className="opacity-50" aria-hidden="true">
-              {icon}
-            </span>
-          )}
-          <input
-            ref={ref}
-            id={id}
-            type={visible ? 'text' : 'password'}
-            className="grow"
-            aria-invalid={error ? true : undefined}
-            aria-describedby={describedBy}
-            aria-required={required || undefined}
-            required={required}
-            {...rest}
-          />
-          {inline && label && <span className="label">{label}</span>}
-          {clearable && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={onClear}
-              aria-label="Clear password"
-              tabIndex={-1}
-            >
-              ✕
-            </button>
-          )}
-          {!hideToggle && (
-            <button
-              type="button"
-              className="opacity-50 hover:opacity-100 cursor-pointer"
-              onClick={() => setVisible((v) => !v)}
-              aria-label={visible ? 'Hide password' : 'Show password'}
-              tabIndex={-1}
-            >
-              {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
-            </button>
-          )}
-        </label>
+        {passwordBox}
         {hint && !error && (
           <p id={hintId} className="fieldset-label">
             {hint}
@@ -165,7 +195,7 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Password/Password.tsx
+++ b/packages/react/src/components/form/Password/Password.tsx
@@ -133,7 +133,6 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={onClear}
             aria-label="Clear password"
-            tabIndex={-1}
           >
             ✕
           </button>
@@ -144,7 +143,6 @@ export const Password = forwardRef<HTMLInputElement, PasswordProps>(
             className="opacity-50 hover:opacity-100 cursor-pointer"
             onClick={() => setVisible((v) => !v)}
             aria-label={visible ? 'Hide password' : 'Show password'}
-            tabIndex={-1}
           >
             {visible ? (visibleIcon ?? <EyeIcon />) : (hiddenIcon ?? <EyeSlashIcon />)}
           </button>

--- a/packages/react/src/components/form/Pin/Pin.tsx
+++ b/packages/react/src/components/form/Pin/Pin.tsx
@@ -179,7 +179,7 @@ export const Pin = forwardRef<HTMLInputElement, PinProps>(
     );
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         <div className="flex gap-2" role="group" aria-label="PIN input">
           {Array.from({ length }).map((_, index) => (
             <input
@@ -222,7 +222,7 @@ export const Pin = forwardRef<HTMLInputElement, PinProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Range/Range.tsx
+++ b/packages/react/src/components/form/Range/Range.tsx
@@ -56,12 +56,12 @@ export const Range = forwardRef<HTMLInputElement, RangeProps>(
     const errorId = error ? `${id}-error` : undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <input
           ref={ref}
@@ -86,7 +86,7 @@ export const Range = forwardRef<HTMLInputElement, RangeProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/RichTextEditor/RichTextEditor.tsx
+++ b/packages/react/src/components/form/RichTextEditor/RichTextEditor.tsx
@@ -117,13 +117,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
       }
     }, [value]);
 
+    const labelId = label ? `${id}-label` : undefined;
+
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && (
-          <legend className="fieldset-legend">
+          <span id={labelId} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </span>
         )}
         <div
           className={cn('border rounded-lg overflow-hidden', error && 'border-error', className)}
@@ -137,7 +139,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             contentEditable
             role="textbox"
             aria-multiline="true"
-            aria-label={label}
+            aria-labelledby={labelId}
             aria-invalid={error ? true : undefined}
             aria-describedby={describedBy}
             className="p-4 outline-none prose max-w-none"
@@ -160,7 +162,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Select/Select.tsx
+++ b/packages/react/src/components/form/Select/Select.tsx
@@ -99,14 +99,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && !inline && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
-        <label className={cn('select', 'w-full', error && 'select-error', className)} htmlFor={id}>
+        <span className={cn('select', 'w-full', error && 'select-error', className)}>
           {icon && (
             <span className="opacity-50" aria-hidden="true">
               {icon}
@@ -143,7 +143,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
               {iconRight}
             </span>
           )}
-        </label>
+        </span>
         {inline && label && (
           <label className="fieldset-label" htmlFor={id}>
             {label}
@@ -159,7 +159,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/form/Textarea/Textarea.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.tsx
@@ -47,12 +47,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
 
     return (
-      <fieldset className="fieldset">
+      <div className="fieldset w-full">
         {label && !inline && (
-          <legend className="fieldset-legend">
+          <label htmlFor={id} className="fieldset-legend">
             {label}
             {required && <span className="text-error ml-1">*</span>}
-          </legend>
+          </label>
         )}
         <textarea
           ref={ref}
@@ -85,7 +85,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             {error}
           </p>
         )}
-      </fieldset>
+      </div>
     );
   },
 );

--- a/packages/react/src/components/layout/Card/Card.tsx
+++ b/packages/react/src/components/layout/Card/Card.tsx
@@ -146,8 +146,9 @@ export const Card = forwardRef<HTMLDivElement | HTMLAnchorElement, CardProps>(
       'card',
       'bg-base-100',
       !noShadow && 'shadow-xl',
-      bordered && 'card-bordered',
-      compact && 'card-compact',
+      bordered && 'card-border',
+      // daisyUI 5 removed card-compact; card-sm is the closest replacement for "reduced padding".
+      compact && 'card-sm',
       glass && 'glass',
       isHorizontal && 'card-side',
       className,

--- a/packages/react/src/components/layout/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/layout/Dropdown/Dropdown.tsx
@@ -100,6 +100,15 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
     const menuRef = useRef<HTMLUListElement>(null);
     const focusedIndex = useRef(-1);
 
+    // Track the latest open state in a ref so `setOpen` and toggle callbacks can read it
+    // without listing it as a dep. Without this, `setOpen` rebuilds on every toggle and the
+    // click-outside effect re-attaches document listeners — fatal in editor-heavy hosts
+    // like Tiptap where document events are already under heavy load (#37).
+    const isOpenRef = useRef(isOpen);
+    useEffect(() => {
+      isOpenRef.current = isOpen;
+    }, [isOpen]);
+
     const setRefs = useCallback(
       (node: HTMLDivElement | null) => {
         containerRef.current = node;
@@ -114,8 +123,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
 
     const setOpen = useCallback(
       (next: boolean) => {
-        const current = isControlled ? open : internalOpen;
-        if (next === current) return;
+        if (next === isOpenRef.current) return;
         if (!isControlled) {
           setInternalOpen(next);
         }
@@ -124,7 +132,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           focusedIndex.current = -1;
         }
       },
-      [isControlled, open, internalOpen, onOpenChange],
+      [isControlled, onOpenChange],
     );
 
     const closeFocusTrigger = useCallback(() => {
@@ -217,7 +225,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
     };
 
     const handleTriggerClick = () => {
-      setOpen(!isOpen);
+      setOpen(!isOpenRef.current);
     };
 
     const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -232,7 +240,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
 
     const menuId = `dropdown-menu-${autoId}`;
 
-    /* eslint-disable react-hooks/refs -- ref writes happen in event handlers, not during render */
     const renderTrigger = () => {
       if (trigger) {
         const triggerEl = trigger as ReactElement<Record<string, unknown>>;
@@ -243,25 +250,46 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           | ((...args: unknown[]) => void)
           | undefined;
 
-        return cloneElement(triggerEl, {
+        const cloneProps: Record<string, unknown> = {
           'aria-haspopup': 'true' as const,
           'aria-expanded': isOpen,
           'aria-controls': menuId,
-          onClick: (e: React.MouseEvent) => {
+        };
+
+        // In controlled mode the consumer owns open state and presumably toggles it in
+        // their own onClick. Layering the library's toggle on top would double-fire
+        // onOpenChange with a stale `isOpen` closure — see #37. We still capture the
+        // triggerRef and forward keydown for accessibility (ArrowDown/Escape).
+        if (isControlled) {
+          cloneProps.onClick = (e: React.MouseEvent) => {
+            triggerRef.current = e.currentTarget as HTMLElement;
+            (originalOnClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
+          };
+          cloneProps.onKeyDown = (e: KeyboardEvent) => {
+            triggerRef.current = e.currentTarget as HTMLElement;
+            originalOnKeyDown?.(e);
+            if (!e.defaultPrevented && (e.key === 'Escape' || e.key === 'ArrowDown')) {
+              handleTriggerKeyDown(e);
+            }
+          };
+        } else {
+          cloneProps.onClick = (e: React.MouseEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             (originalOnClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
             if (!e.defaultPrevented) {
               handleTriggerClick();
             }
-          },
-          onKeyDown: (e: KeyboardEvent) => {
+          };
+          cloneProps.onKeyDown = (e: KeyboardEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             originalOnKeyDown?.(e);
             if (!e.defaultPrevented) {
               handleTriggerKeyDown(e);
             }
-          },
-        });
+          };
+        }
+
+        return cloneElement(triggerEl, cloneProps);
       }
 
       return (
@@ -298,7 +326,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
         {...rest}
       >
         {renderTrigger()}
-        {/* eslint-enable react-hooks/refs */}
         <ul
           ref={menuRef}
           id={menuId}

--- a/packages/react/src/components/layout/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/layout/Dropdown/Dropdown.tsx
@@ -61,13 +61,15 @@ export interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
  *
  * @example
  * ```tsx
- * // Custom trigger with controlled state
+ * // Custom trigger with controlled state. In controlled mode the consumer
+ * // owns the toggle, so the trigger must wire its own onClick (the library
+ * // no longer layers a handler on top, to avoid double-firing onOpenChange).
  * const [open, setOpen] = useState(false);
  *
  * <Dropdown
  *   open={open}
  *   onOpenChange={setOpen}
- *   trigger={<Button>Menu</Button>}
+ *   trigger={<Button onClick={() => setOpen((v) => !v)}>Menu</Button>}
  * >
  *   <DropdownItem onClick={handleEdit}>Edit</DropdownItem>
  * </Dropdown>

--- a/packages/react/src/components/layout/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/layout/Dropdown/Dropdown.tsx
@@ -256,10 +256,11 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           'aria-controls': menuId,
         };
 
-        // In controlled mode the consumer owns open state and presumably toggles it in
-        // their own onClick. Layering the library's toggle on top would double-fire
-        // onOpenChange with a stale `isOpen` closure — see #37. We still capture the
-        // triggerRef and forward keydown for accessibility (ArrowDown/Escape).
+        // In controlled mode the consumer owns open state. Layering the library's
+        // click/keydown toggle on top would double-fire onOpenChange with a stale
+        // closure — see #37. We still capture the triggerRef so focus restoration
+        // on close works, but defer all toggle behavior (including ArrowDown/Escape)
+        // to the consumer's own handlers.
         if (isControlled) {
           cloneProps.onClick = (e: React.MouseEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
@@ -268,9 +269,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
           cloneProps.onKeyDown = (e: KeyboardEvent) => {
             triggerRef.current = e.currentTarget as HTMLElement;
             originalOnKeyDown?.(e);
-            if (!e.defaultPrevented && (e.key === 'Escape' || e.key === 'ArrowDown')) {
-              handleTriggerKeyDown(e);
-            }
           };
         } else {
           cloneProps.onClick = (e: React.MouseEvent) => {

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -269,13 +269,18 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const wrapInFocusable = (content: ReactNode): ReactElement => {
       if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state. Don't bind library
+        // toggle handlers — see #37. The consumer's own children inside the Fragment
+        // are responsible for triggering the toggle through their own onClick.
+        const clickHandlers = isControlled
+          ? {}
+          : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
           <button
             type="button"
             aria-expanded={isOpen}
             aria-controls={contentId}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
+            {...clickHandlers}
           >
             {content}
           </button>
@@ -327,13 +332,19 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
       // Fallback: non-element trigger (string, etc.)
       if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state — skip library toggle
+        // handlers to avoid double-firing onOpenChange (#37). Non-element triggers
+        // (string, number, etc.) in controlled mode rely on the consumer to drive open
+        // state through external means since they have no DOM hook for onClick.
+        const clickHandlers = isControlled
+          ? {}
+          : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
           <button
             type="button"
             aria-expanded={isOpen}
             aria-controls={contentId}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
+            {...clickHandlers}
           >
             {trigger}
           </button>

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -276,12 +276,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           ? {}
           : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
-          <button
-            type="button"
-            aria-expanded={isOpen}
-            aria-controls={contentId}
-            {...clickHandlers}
-          >
+          <button type="button" aria-expanded={isOpen} aria-controls={contentId} {...clickHandlers}>
             {content}
           </button>
         );
@@ -340,12 +335,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           ? {}
           : { onClick: handleClick, onKeyDown: handleKeyDown };
         return (
-          <button
-            type="button"
-            aria-expanded={isOpen}
-            aria-controls={contentId}
-            {...clickHandlers}
-          >
+          <button type="button" aria-expanded={isOpen} aria-controls={contentId} {...clickHandlers}>
             {trigger}
           </button>
         );

--- a/packages/react/src/components/layout/Popover/Popover.tsx
+++ b/packages/react/src/components/layout/Popover/Popover.tsx
@@ -124,6 +124,15 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
 
+    // Track the latest open state in a ref so `setOpen` and toggle callbacks can read it
+    // without listing it as a dep. Without this, `setOpen` rebuilds on every toggle and the
+    // click-outside/Escape effects re-attach document listeners — fatal in editor-heavy hosts
+    // like Tiptap where document events are already under heavy load (#37).
+    const isOpenRef = useRef(isOpen);
+    useEffect(() => {
+      isOpenRef.current = isOpen;
+    }, [isOpen]);
+
     const setRefs = useCallback(
       (node: HTMLDivElement | null) => {
         containerRef.current = node;
@@ -138,14 +147,13 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const setOpen = useCallback(
       (next: boolean) => {
-        const current = isControlled ? open : internalOpen;
-        if (next === current) return;
+        if (next === isOpenRef.current) return;
         if (!isControlled) {
           setInternalOpen(next);
         }
         onOpenChange?.(next);
       },
-      [isControlled, open, internalOpen, onOpenChange],
+      [isControlled, onOpenChange],
     );
 
     const clearTimers = () => {
@@ -231,14 +239,14 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     const handleClick = () => {
       if (triggerMode !== 'click') return;
-      setOpen(!isOpen);
+      setOpen(!isOpenRef.current);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (triggerMode !== 'click') return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        setOpen(!isOpen);
+        setOpen(!isOpenRef.current);
       }
     };
 
@@ -298,7 +306,10 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           props.tabIndex = 0;
         }
 
-        if (triggerMode === 'click') {
+        // In controlled click mode the consumer owns open state and presumably toggles it
+        // in their own onClick. Layering the library's toggle on top would double-fire
+        // onOpenChange with a stale `isOpen` closure — see #37.
+        if (triggerMode === 'click' && !isControlled) {
           const origClick = triggerEl.props.onClick as ((...a: unknown[]) => void) | undefined;
           const origKeyDown = triggerEl.props.onKeyDown as ((...a: unknown[]) => void) | undefined;
           props.onClick = (...args: unknown[]) => {

--- a/packages/react/src/components/layout/Tabs/Tabs.tsx
+++ b/packages/react/src/components/layout/Tabs/Tabs.tsx
@@ -77,9 +77,9 @@ const sizeMap: Record<Size, string> = {
 type Variant = NonNullable<TabsProps['variant']>;
 
 const variantMap: Record<Variant, string> = {
-  bordered: 'tabs-bordered',
-  lifted: 'tabs-lifted',
-  boxed: 'tabs-boxed',
+  bordered: 'tabs-border',
+  lifted: 'tabs-lift',
+  boxed: 'tabs-box',
 };
 
 const colorMap: Record<DaisyColor, string> = {

--- a/packages/react/src/components/navigation/Navbar/Navbar.tsx
+++ b/packages/react/src/components/navigation/Navbar/Navbar.tsx
@@ -33,7 +33,7 @@ export interface NavbarProps extends HTMLAttributes<HTMLElement> {
  * ```tsx
  * <Navbar
  *   start={<a className="text-xl font-bold">MyApp</a>}
- *   center={<input type="text" placeholder="Search..." className="input input-bordered" />}
+ *   center={<input type="text" placeholder="Search..." className="input" />}
  *   end={<button className="btn btn-primary">Login</button>}
  *   glass
  * />

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @artisanpack-ui/tokens
 
+## 1.0.1
+
+### Patch Changes
+
+- Linked version bump alongside `@artisanpack-ui/react@1.0.1` and `@artisanpack-ui/react-laravel@1.0.1`. No source changes in this package.
+
 ## 1.0.0
 
 ### Major Changes
 
 - [`3669646`](https://github.com/ArtisanPack-UI/react/commit/3669646d2dfceb05478ba72e88046e25fad32f25) Thanks [@ViewFromTheBox](https://github.com/ViewFromTheBox)! - Initial release
-
-## 2.0.0
-
-### Major Changes
-
-- [#33](https://github.com/ArtisanPack-UI/react/pull/33) [`0ff7c1c`](https://github.com/ArtisanPack-UI/react/commit/0ff7c1c9aaad9b15be04563d450957f9fc1b80e2) Thanks [@ViewFromTheBox](https://github.com/ViewFromTheBox)! - Initial release

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/tokens",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared design tokens, color resolver, and glass helpers for ArtisanPack UI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,13 @@
     "paths": {
       "@artisanpack-ui/tokens": ["./packages/tokens/src"],
       "@artisanpack-ui/react": ["./packages/react/src"],
+      "@artisanpack-ui/react/form": ["./packages/react/src/components/form"],
+      "@artisanpack-ui/react/layout": ["./packages/react/src/components/layout"],
+      "@artisanpack-ui/react/navigation": ["./packages/react/src/components/navigation"],
+      "@artisanpack-ui/react/data": ["./packages/react/src/components/data"],
+      "@artisanpack-ui/react/chart": ["./packages/react/src/components/data/Chart/Chart"],
+      "@artisanpack-ui/react/feedback": ["./packages/react/src/components/feedback"],
+      "@artisanpack-ui/react/utility": ["./packages/react/src/components/utility"],
       "@artisanpack-ui/react-laravel": ["./packages/react-laravel/src"]
     }
   },


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.0.1
- **Release Date:** 2026-05-25
- **Release Type:** Patch
- **Release Branch:** `release/1.0.1`
- **Target Branch:** `main`

## Release Summary

Bug-fix release for the three linked packages (`@artisanpack-ui/tokens`, `@artisanpack-ui/react`, `@artisanpack-ui/react-laravel`). Addresses four open bugs reported from downstream consumers (`artisanpack-ui/visual-editor`, `artisanpack-ui/forms`, `react-starter-kit`):

- **#39** — `Input` and every other single-control form component was wrapping itself in `<fieldset>`/`<legend>`, which is wrong HTML semantics and produced "Email, group, edit Email" screen-reader output plus a default browser fieldset border on hosts without daisyUI's reset.
- **#36** — `Tabs` and `Card` variants emitted daisyUI v4 class names (`tabs-bordered`, `card-compact`, etc.) that are silently dead on daisyUI v5 hosts. The `variant` prop was a visual no-op.
- **#37** — `Popover` and `Dropdown` froze the main thread when used alongside a Tiptap editor. `setOpen` was rebuilding on every toggle, churning document listeners on every open/close; and in controlled mode the library layered a second toggle on top of the consumer's `onClick`, double-firing `onOpenChange`.
- **#38** — The `@artisanpack-ui/react-laravel` adapter's published dist transitively imported the root barrel of `@artisanpack-ui/react`, dragging the `Chart` component (and its optional `react-apexcharts` peer) into every consumer that did subpath imports like `@artisanpack-ui/react-laravel/feedback`.

No new public API, no breaking changes.

## Changelog

### Added
- None.

### Changed
- Added source-side TypeScript path mappings for every `@artisanpack-ui/react` subpath in the root `tsconfig.json` so the `type-check` CI job resolves subpath imports without a prior `npm run build`.

### Deprecated
- None.

### Removed
- The dead `input-bordered` class is no longer emitted by `Input`. v5's `.input` already includes the border.
- Stale `## 2.0.0` blocks in the per-package CHANGELOGs (leftover from a Changesets reset; never published).

### Fixed
- **`@artisanpack-ui/react` — `<fieldset>`/`<legend>` wrapping single-control form components** (#39, #40). `Input`, `Textarea`, `Password`, `Pin`, `DatePicker`, `Select`, `RichTextEditor`, `Editor`, `File`, `ColorPicker`, and `Range` now render daisyUI v5's `fieldset` utility classes on plain `<div>`/`<label>` elements. Inline-label mode on `Input`, `Password`, and `DatePicker` switched to `floating-label`. `RichTextEditor` uses `aria-labelledby` for its `contenteditable` region. `Radio`, `Checkbox` group, and `Toggle` keep `<fieldset>` since they're genuine groups.
- **`@artisanpack-ui/react` — Keyboard-inaccessible action buttons** (#40). Removed `tabIndex={-1}` from the `Input` clear button and the `Password` clear/visibility-toggle buttons.
- **`@artisanpack-ui/react` — `Tabs` and `Card` variants emitted dead daisyUI v4 class names** (#36, #41). `tabs-bordered`/`tabs-lifted`/`tabs-boxed` → `tabs-border`/`tabs-lift`/`tabs-box`; `card-bordered` → `card-border`; `card-compact` → `card-sm` (v5 removed `card-compact`).
- **`@artisanpack-ui/react` — `Popover` and `Dropdown` main-thread freeze alongside Tiptap** (#37, #42). Stabilized `setOpen` via `isOpenRef` so click-outside and Escape effects don't churn document listeners. In controlled mode the library no longer layers its own toggle on top of the consumer's `onClick`/`onKeyDown` for cloned-element, Fragment, or string triggers.
- **`@artisanpack-ui/react-laravel` — Adapter dist transitively pulled the root `@artisanpack-ui/react` barrel** (#38, #43). All adapter source files now import from narrow `/feedback` and `/navigation` subpaths.

### Security
- None.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #36
- Closes #37
- Closes #38
- Closes #39

**Related PRs (merged into `release/1.0.1`):**
- #40 — fix: remove fieldset/legend wrapping single-control form components
- #41 — fix: replace dead daisyUI 4 class names with daisyUI 5 equivalents
- #42 — fix: stop Popover/Dropdown from freezing the main thread alongside Tiptap
- #43 — fix: import @artisanpack-ui/react from narrow subpaths in react-laravel

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

`Card` consumers passing `compact` now get `card-sm` styling instead of v4's `card-compact`. Visual sizing should be very close but not pixel-identical; this is the closest v5 equivalent since daisyUI v5 removed `card-compact`.

## Testing Checklist

- [x] All automated tests passing — `@artisanpack-ui/react` 715/715, `@artisanpack-ui/react-laravel` 56/56
- [x] Manual testing completed — verified in `artisanpack-ui/visual-editor` and the affected Keystone CMS consumer before merging #40/#42/#43
- [x] Accessibility tests passing — added regression tests asserting no `<fieldset>`/`<legend>` wraps a single control, plus label↔input association for every affected component
- [ ] Performance tests passing (no perf benchmarks exist; #37 freeze fix verified by repro in the consumer)
- [x] Security scan completed — `npm audit` reports 3 moderate + 1 high vulnerabilities in dev-dependencies (vite, postcss, ws, brace-expansion). All build/test tooling — none ship in the published packages.
- [x] Tested in staging environment — consumed via `cp dist/.` into the affected app
- [ ] Database migrations tested — n/a

**Testing notes:** The Tiptap freeze fix (#37) is hard to repro in jsdom because jsdom doesn't exercise Tiptap's real runtime; verified manually in Safari/Chrome against the visual-editor branch.

## Documentation Checklist

- [x] CHANGELOG updated (root + per-package)
- [x] README updated — n/a, no version-bound content
- [x] API documentation updated — n/a, no public-API changes
- [ ] Migration guide written — n/a, no breaking changes
- [x] Release notes written
- [x] Wiki updated — n/a, no surface changes

## Pre-Release Checklist

- [x] Version number updated in all necessary files (3 × `package.json` from 1.0.0 → 1.0.1; `package-lock.json` synced)
- [x] Git tag prepared: `v1.0.1` (will be created on merge)
- [x] Release branch updated: `release/1.0.1`
- [x] Dependencies updated and tested — lockfile in sync; `npm audit` results captured above
- [x] Build artifacts generated — `npm run build --workspaces` clean
- [x] Deployment plan reviewed (Changesets publish via `ci.yml`)
- [x] Rollback plan prepared (unpublish 1.0.1 from npm and consumers downgrade to ^1.0.0)
- [ ] Stakeholders notified — pending

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. CI's `ci.yml` workflow runs `changeset publish` on the merge, which pushes `@artisanpack-ui/tokens@1.0.1`, `@artisanpack-ui/react@1.0.1`, and `@artisanpack-ui/react-laravel@1.0.1` to npm under the `latest` tag.
3. Tag `v1.0.1` is created on `main`.

**Rollback plan:**
1. Run `npm deprecate @artisanpack-ui/<pkg>@1.0.1 "use ^1.0.0"` for each of the three packages.
2. Consumers downgrade by pinning `^1.0.0`.

**Configuration changes:**
- None.

**Environment variables:**
- None.

## Post-Release Tasks

- [ ] Tag created: `v1.0.1`
- [ ] Release notes published (auto-generated from this PR)
- [ ] Documentation deployed — n/a, no docs site
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented — `1.0.0` remains usable; this is a strict bug-fix bump

## Notes

The per-package CHANGELOGs previously contained stale `## 2.0.0` blocks left over from a Changesets cycle that was reset before publishing. Those have been removed in this PR so the per-package histories now read `1.0.1 → 1.0.0`, matching what's actually on npm.

The root `tsconfig.json` gained source-side path mappings for every `@artisanpack-ui/react` subpath so the `type-check` job no longer depends on a prior `npm run build`. This was discovered while fixing #38's CI run.

---

**Release Manager:** @ViewFromTheBox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form accessibility and label associations; preserved focusability for control buttons
  * Updated styling to daisyUI v5 class mappings for components (cards, tabs, etc.)
  * Stabilized Popover/Dropdown event handling to prevent duplicate actions and main-thread freezes
  * Prevented unnecessary bundling of chart-related peers by narrowing adapter imports

* **Chores**
  * Published patch releases and updated package versions and TypeScript path mappings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/react/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->