### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-06
+
+### Added
+
+- **`@artisanpack-ui/react` — new `ai/` subpath** ([ArtisanPack-UI/ai#17](https://github.com/ArtisanPack-UI/ai/issues/17), [#45](https://github.com/ArtisanPack-UI/react/pull/45)). Drop-in React components + hooks that consume the `artisanpack-ui/ai` JSON API without pulling in Livewire:
+  - `SettingsPage` — provider credentials + per-feature model/instructions overrides backed by `GET/PUT /settings` with an inline `test-connection` probe. Handles Sanctum 422 validation errors and clears the typed key + last probe result on provider switch.
+  - `UsageDashboard` — totals, per-feature breakdown, and daily buckets from `GET /usage`. Optional `refreshInterval` prop enables polling for live updates; sequence-guarded so out-of-order responses can't clobber fresher ones.
+  - `FeatureToggles` — optimistic per-feature enable/disable list backed by `GET /features` + `POST /features/{key}/toggle`, with rollback + error surfacing on API failure.
+  - `createAiApiClient` — small `fetch` wrapper with `AiApiError` for 422 handling; omits `Content-Type` on GET so strict reverse-proxies don't 415.
+  - `useStreamingText` — hook that consumes a `fetch` response body as a UTF-8 text stream via the Streams API + `AbortController`, for long-running agent-output surfaces.
+  - Storybook stories for each component backed by an in-memory mock client.
+  - Full Vitest coverage (19 new tests).
+
 ## [1.0.1] - 2026-05-25
 
 ### Fixed

--- a/docs/AI-Components.md
+++ b/docs/AI-Components.md
@@ -1,0 +1,191 @@
+# AI Components
+
+React components + hooks for consuming the [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai) JSON API. Shipped as the `@artisanpack-ui/react/ai` subpath in 1.0.2.
+
+The subpath gives Laravel apps a drop-in replacement for the Livewire admin surfaces (Settings page, Usage dashboard, Feature toggles) so React starter kits don't have to depend on Livewire.
+
+## Installation
+
+`@artisanpack-ui/react/ai` ships inside `@artisanpack-ui/react` — no extra install needed:
+
+```bash
+npm install @artisanpack-ui/react
+```
+
+The subpath is optional. If you never import from `@artisanpack-ui/react/ai`, none of these components are pulled into your bundle.
+
+## Quick start
+
+```tsx
+import {
+  createAiApiClient,
+  SettingsPage,
+  UsageDashboard,
+  FeatureToggles,
+} from '@artisanpack-ui/react/ai';
+
+const client = createAiApiClient({
+  baseUrl: '/api/artisanpack-ai',
+  headers: {
+    'X-CSRF-TOKEN':
+      document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
+  },
+});
+
+export function AiAdminPage() {
+  return (
+    <div className="flex flex-col gap-8">
+      <SettingsPage client={client} heading="AI Settings" />
+      <UsageDashboard client={client} refreshInterval={15_000} heading="Usage" />
+      <FeatureToggles client={client} heading="Features" />
+    </div>
+  );
+}
+```
+
+## `createAiApiClient`
+
+Builds a small `fetch` wrapper implementing the `AiApiClient` contract every component depends on.
+
+```ts
+const client = createAiApiClient({
+  baseUrl: '/api/artisanpack-ai',
+  headers: { Authorization: `Bearer ${token}` },
+  fetchImpl: (input, init) => fetch(input, { ...init, credentials: 'include' }),
+});
+```
+
+| Option      | Type                       | Notes                                                                                        |
+|-------------|----------------------------|----------------------------------------------------------------------------------------------|
+| `baseUrl`   | `string`                   | Prefix for every request. Match the ai package's route prefix (default `/api/artisanpack-ai`). |
+| `headers`   | `Record<string, string>`   | Merged into every request. Use for CSRF, Sanctum bearer, or custom headers.                  |
+| `fetchImpl` | `typeof fetch`             | Override the global `fetch`. Use for tests or to set `credentials: 'include'` on cross-origin Sanctum. |
+
+Non-2xx responses reject with `AiApiError`, which exposes `.status` and the parsed `.body` — perfect for surfacing Laravel's 422 `{ message, errors }` envelope inline.
+
+If your app has its own HTTP layer (Axios, Ky, a Sanctum-aware wrapper), implement the `AiApiClient` interface directly rather than using `createAiApiClient`. Every component depends on the interface, not on `fetch`.
+
+## `<SettingsPage>`
+
+Admin form backed by `GET/PUT /settings` and `POST /test-connection`. Renders provider credentials, per-feature model/instruction overrides, and a probe button that surfaces `test-connection` results inline.
+
+```tsx
+<SettingsPage
+  client={client}
+  heading="AI Settings"
+  providers={['openai', 'anthropic', 'ollama']}
+/>
+```
+
+| Prop        | Type                      | Default                                    | Notes                                              |
+|-------------|---------------------------|--------------------------------------------|----------------------------------------------------|
+| `client`    | `AiApiClient`             | —                                          | Required.                                          |
+| `providers` | `string[]`                | `['openai', 'anthropic', 'ollama']`        | Options rendered in the provider dropdown.         |
+| `heading`   | `string`                  | —                                          | Optional heading rendered above the form.          |
+
+Behaviour worth knowing:
+
+- **Never emits the stored key.** The API returns `api_key_present: boolean`, not the plaintext key. The password input renders empty by default so a user can leave it blank to keep whatever's already stored.
+- **Provider switch is safe.** Changing provider clears the typed key + last probe result so an OpenAI key never silently ships to an Ollama base URL.
+- **422 errors render inline.** Field-level messages from the `{ errors: Record<string, string[]> }` envelope render under the offending input; a network error (or other non-422 failure) renders in the top alert with the `alert-error` styling instead of the green success one.
+
+## `<UsageDashboard>`
+
+Aggregated dashboard backed by `GET /usage`. Renders totals, per-feature breakdown, and daily buckets.
+
+```tsx
+<UsageDashboard
+  client={client}
+  from="2026-07-01"
+  to="2026-07-31"
+  refreshInterval={15_000}
+  heading="Usage"
+/>
+```
+
+| Prop              | Type          | Default | Notes                                                                                              |
+|-------------------|---------------|---------|----------------------------------------------------------------------------------------------------|
+| `client`          | `AiApiClient` | —       | Required.                                                                                          |
+| `from`            | `string`      | —       | ISO date (`YYYY-MM-DD`). Forwarded to `/usage` as a query param.                                   |
+| `to`              | `string`      | —       | ISO date (`YYYY-MM-DD`). Forwarded to `/usage` as a query param.                                   |
+| `refreshInterval` | `number`      | `0`     | Poll interval in milliseconds. `0` disables polling. `15000` matches the Livewire dashboard cadence.|
+| `heading`         | `string`      | —       | Optional heading rendered above the dashboard.                                                     |
+
+Behaviour worth knowing:
+
+- **Sequence-guarded polling.** Every fetch increments an internal request counter; only the most recent response updates state. Under slow networks (`fetch` latency > `refreshInterval`), a stale response can't overwrite a fresher one.
+- **Reloads on prop change.** Passing controlled `from`/`to` values from a date-range picker just works — the dashboard reloads automatically.
+
+## `<FeatureToggles>`
+
+Per-feature enable/disable list backed by `GET /features` and `POST /features/{key}/toggle`. Each row optimistically flips its own switch and rolls back on API failure.
+
+```tsx
+<FeatureToggles
+  client={client}
+  heading="Features"
+  onToggle={(feature) => console.log(feature)}
+/>
+```
+
+| Prop       | Type                                                                | Notes                                                                          |
+|------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `client`   | `AiApiClient`                                                       | Required.                                                                      |
+| `heading`  | `string`                                                            | Optional heading — kept visible in loading, empty, and error states.           |
+| `onToggle` | `(feature: { key; package; enabled }) => void`                      | Fired after a successful toggle. Not fired on rollback.                        |
+
+Behaviour worth knowing:
+
+- **Optimistic + reversible.** The switch flips immediately; only if the POST rejects does the row roll back and surface an error banner. A subsequent successful toggle clears the banner.
+- **Empty state keeps context.** When no features are registered, the heading still renders above the "No AI features registered." message.
+
+## `useStreamingText`
+
+Hook for consuming a long-running `fetch` response body as a UTF-8 text stream — useful for the AI usage dashboard's long-running agent-output surface, chain-of-thought output, or any streamed generation.
+
+```tsx
+import { useStreamingText } from '@artisanpack-ui/react/ai';
+
+function AgentOutput({ agentUrl }: { agentUrl: string }) {
+  const { text, streaming, error, start, stop, reset } = useStreamingText();
+
+  return (
+    <div>
+      <button onClick={() => start(agentUrl)} disabled={streaming}>
+        Run
+      </button>
+      <button onClick={stop} disabled={!streaming}>
+        Stop
+      </button>
+      <button onClick={reset}>Clear</button>
+      <pre>
+        {text}
+        {streaming && '…'}
+      </pre>
+      {error && <span role="alert">{error.message}</span>}
+    </div>
+  );
+}
+```
+
+The hook uses the browser Streams API + an `AbortController`. It aborts the in-flight stream automatically on unmount, and rapidly re-calling `start()` cleanly cancels the previous stream without a race — a stale finally block will never flip `streaming` back to `false` while a newer stream is still reading.
+
+> **Note:** `useStreamingText` is a client-side consumer, not a wire protocol. The `artisanpack-ui/ai` package's public REST surface does not include a streaming route — you point the hook at whatever URL your own app exposes (e.g. a custom controller that returns a `StreamedResponse`).
+
+## Exported types
+
+Every wire-level type mirrors the ai package's OpenAPI schema:
+
+- `AiApiClient`, `AiApiError`
+- `AiCredentials`, `AiSettingsResponse`, `AiSettingsUpdate`, `AiFeatureOverride`
+- `AiFeature`
+- `AiConnectionTestResult`
+- `AiUsageResponse`, `AiUsageTotals`, `AiUsageByFeature`, `AiUsageDaily`
+- `AiValidationError`
+
+Import them from `@artisanpack-ui/react/ai` if you write your own client or components.
+
+## Related
+
+- [artisanpack-ui/ai](https://github.com/ArtisanPack-UI/ai) — the Laravel package that ships the REST endpoints
+- [artisanpack-ui/vue](https://github.com/ArtisanPack-UI/vue) — Vue port of the same surface

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -28,6 +28,7 @@ A comprehensive React UI component ecosystem for building modern web application
 - [[Data Display Components]] — Table, Chart, Calendar, Avatar, Badge, Progress, Stat, Timeline, Carousel, Code, Diff
 - [[Feedback Components]] — Alert, Toast, Loading, Skeleton, EmptyState, ErrorDisplay
 - [[Utility Components]] — Icon, ThemeToggle, Tooltip, Clipboard, Markdown
+- [[AI Components]] — SettingsPage, UsageDashboard, FeatureToggles, `createAiApiClient`, `useStreamingText` (`@artisanpack-ui/react/ai` subpath)
 
 ## Development
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -19,6 +19,7 @@
 - [[Data Display Components]]
 - [[Feedback Components]]
 - [[Utility Components]]
+- [[AI Components]]
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10179,7 +10179,7 @@
     },
     "packages/react": {
       "name": "@artisanpack-ui/react",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/tokens": "*"
@@ -10216,7 +10216,7 @@
     },
     "packages/react-laravel": {
       "name": "@artisanpack-ui/react-laravel",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/react": "*"
@@ -10488,7 +10488,7 @@
     },
     "packages/tokens": {
       "name": "@artisanpack-ui/tokens",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "clsx": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -895,7 +894,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,7 +942,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1867,6 +1864,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2841,7 +2845,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3006,7 +3011,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3244,6 +3248,27 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -3370,7 +3395,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3769,7 +3793,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4214,7 +4237,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4238,7 +4260,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4524,7 +4545,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "8.6.0",
@@ -4812,7 +4834,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4877,7 +4898,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6420,7 +6440,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6627,7 +6646,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6976,6 +6994,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7673,7 +7692,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7742,7 +7760,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7759,6 +7776,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7774,6 +7792,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7786,7 +7805,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7854,7 +7874,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7944,7 +7963,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8597,7 +8615,6 @@
       "integrity": "sha512-tMoRAts9EVqf+mEMPLC6z1DPyHbcPe+CV1MhLN55IKsl0HxNjvVGK44rVPSePbltPE6vIsn4bdRj6CCUt8SJwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -9031,8 +9048,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -9146,7 +9162,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9445,7 +9460,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9610,7 +9624,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9704,7 +9717,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10112,7 +10124,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10132,7 +10143,7 @@
     },
     "packages/react": {
       "name": "@artisanpack-ui/react",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/tokens": "*"
@@ -10169,7 +10180,7 @@
     },
     "packages/react-laravel": {
       "name": "@artisanpack-ui/react-laravel",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@artisanpack-ui/react": "*"
@@ -10191,34 +10202,6 @@
         "@inertiajs/react": "^2.0.0 || ^3.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "packages/react-laravel/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/react-laravel/node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "packages/react-laravel/node_modules/data-urls": {
@@ -10381,41 +10364,12 @@
         "node": ">=18"
       }
     },
-    "packages/react/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/react/node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "packages/react/node_modules/apexcharts": {
       "version": "3.45.2",
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.45.2.tgz",
       "integrity": "sha512-PpuM4sJWy70sUh5U1IFn1m1p45MdHSChLUNnqEoUUUHSU2IHZugFrsVNhov1S8Q0cvfdrCRCvdBtHGSs6PSAWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@yr/monotone-cubic-spline": "^1.0.3",
         "svg.draggable.js": "^2.2.2",
@@ -10442,7 +10396,7 @@
     },
     "packages/tokens": {
       "name": "@artisanpack-ui/tokens",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "clsx": "^2.1.1",

--- a/packages/react-laravel/CHANGELOG.md
+++ b/packages/react-laravel/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @artisanpack-ui/react-laravel
 
+## 1.0.2
+
+### Patch Changes
+
+- Linked version bump alongside `@artisanpack-ui/react@1.0.2` and `@artisanpack-ui/tokens@1.0.2`. No source changes in this adapter package.
+
+### Updated dependencies
+
+- `@artisanpack-ui/react@1.0.2`
+- `@artisanpack-ui/tokens@1.0.2`
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/react-laravel/package.json
+++ b/packages/react-laravel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/react-laravel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inertia.js adapter wrappers for ArtisanPack UI React components",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @artisanpack-ui/react
 
+## 1.0.2
+
+### Minor Changes
+
+- [#45](https://github.com/ArtisanPack-UI/react/pull/45) Add a new `ai/` subpath ([ArtisanPack-UI/ai#17](https://github.com/ArtisanPack-UI/ai/issues/17)) — drop-in React components + hooks that consume the `artisanpack-ui/ai` JSON API. Ships `SettingsPage` (GET/PUT `/settings` + `test-connection` probe, provider-switch clears the typed key), `UsageDashboard` (GET `/usage` with sequence-guarded polling via `refreshInterval`), `FeatureToggles` (optimistic POST `/features/{key}/toggle` with rollback on failure), `createAiApiClient` (small fetch wrapper with `AiApiError` for 422 handling; skips `Content-Type` on GET), and `useStreamingText` (hook that reads a `fetch` response body as a UTF-8 text stream via the Streams API + `AbortController`). Storybook stories for every component and full Vitest coverage (19 new tests).
+
+### Updated dependencies
+
+- `@artisanpack-ui/tokens@1.0.2`
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "80+ React UI components for the ArtisanPack UI ecosystem, styled with DaisyUI and Tailwind CSS",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,10 @@
     "./utility": {
       "import": "./dist/utility.mjs",
       "types": "./dist/utility.d.ts"
+    },
+    "./ai": {
+      "import": "./dist/ai.mjs",
+      "types": "./dist/ai.d.ts"
     }
   },
   "files": [

--- a/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
+++ b/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
@@ -5,7 +5,13 @@ import { createMockClient } from './testClient';
 import type { AiFeature } from '../../components/ai/types';
 
 const features: AiFeature[] = [
-  { key: 'summarize', package: 'core', label: 'Summarize', description: 'Short summaries', enabled: true },
+  {
+    key: 'summarize',
+    package: 'core',
+    label: 'Summarize',
+    description: 'Short summaries',
+    enabled: true,
+  },
   { key: 'chat', package: 'core', label: 'Chat', description: null, enabled: false },
 ];
 
@@ -27,7 +33,9 @@ describe('FeatureToggles', () => {
   });
 
   it('flips a toggle via POST /features/{key}/toggle and fires onToggle', async () => {
-    const toggle = vi.fn().mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const toggle = vi
+      .fn()
+      .mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
     const client = createMockClient({
       getFeatures: vi.fn().mockResolvedValue({ features }),
       toggleFeature: toggle,
@@ -42,7 +50,9 @@ describe('FeatureToggles', () => {
     });
 
     expect(toggle).toHaveBeenCalledWith('chat', true);
-    await waitFor(() => expect(onToggle).toHaveBeenCalledWith({ key: 'chat', package: 'core', enabled: true }));
+    await waitFor(() =>
+      expect(onToggle).toHaveBeenCalledWith({ key: 'chat', package: 'core', enabled: true }),
+    );
   });
 
   it('rolls the switch back and surfaces the error when the API rejects', async () => {

--- a/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
+++ b/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
@@ -72,6 +72,32 @@ describe('FeatureToggles', () => {
     expect((screen.getByLabelText('Toggle Summarize') as HTMLInputElement).checked).toBe(true);
   });
 
+  it('clears a stale error after a subsequent successful toggle', async () => {
+    const toggleFeature = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Boom'))
+      .mockResolvedValueOnce({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature,
+    });
+
+    render(<FeatureToggles client={client} />);
+
+    const summarizeToggle = await screen.findByLabelText('Toggle Summarize');
+    await act(async () => {
+      fireEvent.click(summarizeToggle);
+    });
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'));
+
+    const chatToggle = screen.getByLabelText('Toggle Chat');
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+
   it('renders empty state when no features are registered', async () => {
     const client = createMockClient({
       getFeatures: vi.fn().mockResolvedValue({ features: [] }),

--- a/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
+++ b/packages/react/src/__tests__/ai/FeatureToggles.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { FeatureToggles } from '../../components/ai/FeatureToggles/FeatureToggles';
+import { createMockClient } from './testClient';
+import type { AiFeature } from '../../components/ai/types';
+
+const features: AiFeature[] = [
+  { key: 'summarize', package: 'core', label: 'Summarize', description: 'Short summaries', enabled: true },
+  { key: 'chat', package: 'core', label: 'Chat', description: null, enabled: false },
+];
+
+describe('FeatureToggles', () => {
+  it('renders each registered feature and its enabled state', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+    });
+
+    render(<FeatureToggles client={client} heading="AI Features" />);
+
+    expect(await screen.findByText('Summarize')).toBeInTheDocument();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+
+    const summarizeToggle = screen.getByLabelText('Toggle Summarize') as HTMLInputElement;
+    const chatToggle = screen.getByLabelText('Toggle Chat') as HTMLInputElement;
+    expect(summarizeToggle.checked).toBe(true);
+    expect(chatToggle.checked).toBe(false);
+  });
+
+  it('flips a toggle via POST /features/{key}/toggle and fires onToggle', async () => {
+    const toggle = vi.fn().mockResolvedValue({ feature: { key: 'chat', package: 'core', enabled: true } });
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature: toggle,
+    });
+    const onToggle = vi.fn();
+
+    render(<FeatureToggles client={client} onToggle={onToggle} />);
+
+    const chatToggle = (await screen.findByLabelText('Toggle Chat')) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    expect(toggle).toHaveBeenCalledWith('chat', true);
+    await waitFor(() => expect(onToggle).toHaveBeenCalledWith({ key: 'chat', package: 'core', enabled: true }));
+  });
+
+  it('rolls the switch back and surfaces the error when the API rejects', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features }),
+      toggleFeature: vi.fn().mockRejectedValue(new Error('Boom')),
+    });
+
+    render(<FeatureToggles client={client} />);
+
+    const summarizeToggle = (await screen.findByLabelText('Toggle Summarize')) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.click(summarizeToggle);
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'));
+    expect((screen.getByLabelText('Toggle Summarize') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('renders empty state when no features are registered', async () => {
+    const client = createMockClient({
+      getFeatures: vi.fn().mockResolvedValue({ features: [] }),
+    });
+
+    render(<FeatureToggles client={client} />);
+
+    expect(await screen.findByText('No AI features registered.')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/__tests__/ai/SettingsPage.test.tsx
+++ b/packages/react/src/__tests__/ai/SettingsPage.test.tsx
@@ -57,13 +57,15 @@ describe('SettingsPage', () => {
   it('renders per-field validation errors returned from a 422', async () => {
     const client = createMockClient({
       getSettings: vi.fn().mockResolvedValue(baseResponse),
-      updateSettings: vi.fn().mockRejectedValue(
-        new AiApiError(
-          422,
-          { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
-          'Validation failed.',
+      updateSettings: vi
+        .fn()
+        .mockRejectedValue(
+          new AiApiError(
+            422,
+            { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
+            'Validation failed.',
+          ),
         ),
-      ),
     });
 
     render(<SettingsPage client={client} />);

--- a/packages/react/src/__tests__/ai/SettingsPage.test.tsx
+++ b/packages/react/src/__tests__/ai/SettingsPage.test.tsx
@@ -95,4 +95,59 @@ describe('SettingsPage', () => {
 
     expect(await screen.findByText('Connected')).toBeInTheDocument();
   });
+
+  it('clears the typed api_key and last probe result when switching providers', async () => {
+    const testConnection = vi
+      .fn()
+      .mockResolvedValue({ result: 'ok', message: 'Connected', provider: 'openai' });
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      testConnection,
+    });
+
+    render(<SettingsPage client={client} />);
+    await screen.findByDisplayValue('gpt-4o-mini');
+
+    const apiKeyInput = screen.getByPlaceholderText('••••••••') as HTMLInputElement;
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-secret' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    });
+    await screen.findByText('Connected');
+
+    const providerSelect = screen.getByRole('combobox') as HTMLSelectElement;
+    fireEvent.change(providerSelect, { target: { value: 'ollama' } });
+
+    // API key field is hidden for Ollama; probe result is cleared.
+    expect(screen.queryByPlaceholderText('••••••••')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+
+    // Re-probe should not ship the stale OpenAI key to the ollama base URL.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    });
+    const lastCall = testConnection.mock.calls.at(-1)?.[0];
+    expect(lastCall.provider).toBe('ollama');
+    expect(lastCall.api_key).toBeNull();
+  });
+
+  it('renders a network error inside an error alert, not a success alert', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: vi.fn().mockRejectedValue(new Error('Network down')),
+    });
+
+    render(<SettingsPage client={client} />);
+    await screen.findByDisplayValue('gpt-4o-mini');
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('ai-settings-page'));
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Network down');
+    expect(alert).toHaveClass('alert-error');
+    expect(alert).not.toHaveClass('alert-success');
+  });
 });

--- a/packages/react/src/__tests__/ai/SettingsPage.test.tsx
+++ b/packages/react/src/__tests__/ai/SettingsPage.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { SettingsPage } from '../../components/ai/SettingsPage/SettingsPage';
+import { AiApiError } from '../../components/ai/createAiApiClient';
+import { createMockClient } from './testClient';
+import type { AiSettingsResponse } from '../../components/ai/types';
+
+const baseResponse: AiSettingsResponse = {
+  credentials: {
+    provider: 'openai',
+    api_key_present: true,
+    base_url: null,
+    default_model: 'gpt-4o-mini',
+  },
+  feature_overrides: [
+    { feature_key: 'summarize', package: 'core', model: null, instructions: null },
+  ],
+};
+
+describe('SettingsPage', () => {
+  it('loads and renders the current settings', async () => {
+    const client = createMockClient({ getSettings: vi.fn().mockResolvedValue(baseResponse) });
+
+    render(<SettingsPage client={client} heading="AI Settings" />);
+
+    expect(await screen.findByRole('heading', { name: 'AI Settings' })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('gpt-4o-mini')).toBeInTheDocument();
+    expect(screen.getByText(/leave blank to keep the stored key/)).toBeInTheDocument();
+  });
+
+  it('submits the form via PUT /settings and shows a success status', async () => {
+    const update = vi.fn().mockResolvedValue({
+      ...baseResponse,
+      credentials: { ...baseResponse.credentials, default_model: 'gpt-4o' },
+    });
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: update,
+    });
+
+    render(<SettingsPage client={client} />);
+
+    const modelInput = (await screen.findByDisplayValue('gpt-4o-mini')) as HTMLInputElement;
+    fireEvent.change(modelInput, { target: { value: 'gpt-4o' } });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('ai-settings-page'));
+    });
+
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    const payload = update.mock.calls[0][0];
+    expect(payload.default_model).toBe('gpt-4o');
+    expect(payload.api_key).toBeNull();
+    expect(await screen.findByText('Settings saved.')).toBeInTheDocument();
+  });
+
+  it('renders per-field validation errors returned from a 422', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      updateSettings: vi.fn().mockRejectedValue(
+        new AiApiError(
+          422,
+          { message: 'Validation failed.', errors: { api_key: ['An API key is required.'] } },
+          'Validation failed.',
+        ),
+      ),
+    });
+
+    render(<SettingsPage client={client} />);
+    await screen.findByDisplayValue('gpt-4o-mini');
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('ai-settings-page'));
+    });
+
+    expect(await screen.findByText('An API key is required.')).toBeInTheDocument();
+  });
+
+  it('probes the provider via test-connection and surfaces the result', async () => {
+    const client = createMockClient({
+      getSettings: vi.fn().mockResolvedValue(baseResponse),
+      testConnection: vi
+        .fn()
+        .mockResolvedValue({ result: 'ok', message: 'Connected', provider: 'openai' }),
+    });
+
+    render(<SettingsPage client={client} />);
+    await screen.findByDisplayValue('gpt-4o-mini');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    });
+
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/__tests__/ai/UsageDashboard.test.tsx
+++ b/packages/react/src/__tests__/ai/UsageDashboard.test.tsx
@@ -14,10 +14,24 @@ const usage: AiUsageResponse = {
     cost: 0.42,
   },
   by_feature: [
-    { feature_key: 'summarize', requests: 8, input_tokens: 800, output_tokens: 300, total_tokens: 1100, cost: 0.3 },
+    {
+      feature_key: 'summarize',
+      requests: 8,
+      input_tokens: 800,
+      output_tokens: 300,
+      total_tokens: 1100,
+      cost: 0.3,
+    },
   ],
   daily: [
-    { period: '2026-07-01', requests: 5, input_tokens: 500, output_tokens: 250, total_tokens: 750, cost: 0.21 },
+    {
+      period: '2026-07-01',
+      requests: 5,
+      input_tokens: 500,
+      output_tokens: 250,
+      total_tokens: 750,
+      cost: 0.21,
+    },
   ],
 };
 

--- a/packages/react/src/__tests__/ai/UsageDashboard.test.tsx
+++ b/packages/react/src/__tests__/ai/UsageDashboard.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UsageDashboard } from '../../components/ai/UsageDashboard/UsageDashboard';
+import { createMockClient } from './testClient';
+import type { AiUsageResponse } from '../../components/ai/types';
+
+const usage: AiUsageResponse = {
+  range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
+  totals: {
+    requests: 12,
+    input_tokens: 1000,
+    output_tokens: 500,
+    total_tokens: 1500,
+    cost: 0.42,
+  },
+  by_feature: [
+    { feature_key: 'summarize', requests: 8, input_tokens: 800, output_tokens: 300, total_tokens: 1100, cost: 0.3 },
+  ],
+  daily: [
+    { period: '2026-07-01', requests: 5, input_tokens: 500, output_tokens: 250, total_tokens: 750, cost: 0.21 },
+  ],
+};
+
+describe('UsageDashboard', () => {
+  it('renders totals, by_feature, and daily buckets from GET /usage', async () => {
+    const client = createMockClient({ getUsage: vi.fn().mockResolvedValue(usage) });
+
+    render(<UsageDashboard client={client} heading="Usage" />);
+
+    expect(await screen.findByText('Usage')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('summarize')).toBeInTheDocument();
+    expect(screen.getByText('2026-07-01')).toBeInTheDocument();
+  });
+
+  it('forwards from/to as query params to the API client', async () => {
+    const getUsage = vi.fn().mockResolvedValue(usage);
+    const client = createMockClient({ getUsage });
+
+    render(<UsageDashboard client={client} from="2026-07-01" to="2026-07-15" />);
+
+    await screen.findByText('12');
+    expect(getUsage).toHaveBeenCalledWith({ from: '2026-07-01', to: '2026-07-15' });
+  });
+
+  it('polls at refreshInterval for live updates', async () => {
+    vi.useFakeTimers();
+    const getUsage = vi.fn().mockResolvedValue(usage);
+    const client = createMockClient({ getUsage });
+
+    render(<UsageDashboard client={client} refreshInterval={1000} />);
+
+    await vi.waitFor(() => expect(getUsage).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getUsage).toHaveBeenCalledTimes(4);
+
+    vi.useRealTimers();
+  });
+
+  it('surfaces a fetch error when the initial load fails', async () => {
+    const client = createMockClient({ getUsage: vi.fn().mockRejectedValue(new Error('Nope')) });
+
+    render(<UsageDashboard client={client} />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Nope');
+  });
+});

--- a/packages/react/src/__tests__/ai/createAiApiClient.test.ts
+++ b/packages/react/src/__tests__/ai/createAiApiClient.test.ts
@@ -13,7 +13,15 @@ describe('createAiApiClient', () => {
     const fetchImpl = mockFetch((url) => {
       expect(url).toBe('/api/artisanpack-ai/settings');
       return new Response(
-        JSON.stringify({ credentials: { provider: 'openai', api_key_present: false, base_url: null, default_model: null }, feature_overrides: [] }),
+        JSON.stringify({
+          credentials: {
+            provider: 'openai',
+            api_key_present: false,
+            base_url: null,
+            default_model: null,
+          },
+          feature_overrides: [],
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     });
@@ -38,11 +46,15 @@ describe('createAiApiClient', () => {
   });
 
   it('rejects non-2xx responses with AiApiError including the parsed body', async () => {
-    const fetchImpl = mockFetch(() =>
-      new Response(JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }), {
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    const fetchImpl = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }),
+          {
+            status: 422,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
     );
 
     const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
@@ -64,9 +76,12 @@ describe('createAiApiClient', () => {
     const fetchImpl = mockFetch((url, init) => {
       expect(url).toBe('/api/artisanpack-ai/features/summarize.post/toggle');
       expect(init?.method).toBe('POST');
-      return new Response(JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }), {
-        status: 200,
-      });
+      return new Response(
+        JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }),
+        {
+          status: 200,
+        },
+      );
     });
 
     const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });

--- a/packages/react/src/__tests__/ai/createAiApiClient.test.ts
+++ b/packages/react/src/__tests__/ai/createAiApiClient.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AiApiError, createAiApiClient } from '../../components/ai/createAiApiClient';
+
+function mockFetch(handler: (input: string, init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    return Promise.resolve(handler(url, init));
+  }) as unknown as typeof fetch;
+}
+
+describe('createAiApiClient', () => {
+  it('GETs settings from the configured base URL', async () => {
+    const fetchImpl = mockFetch((url) => {
+      expect(url).toBe('/api/artisanpack-ai/settings');
+      return new Response(
+        JSON.stringify({ credentials: { provider: 'openai', api_key_present: false, base_url: null, default_model: null }, feature_overrides: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai/', fetchImpl });
+    const response = await client.getSettings();
+
+    expect(response.credentials.provider).toBe('openai');
+  });
+
+  it('serializes usage query params', async () => {
+    const fetchImpl = mockFetch((url) => {
+      expect(url).toBe('/api/artisanpack-ai/usage?from=2026-07-01&to=2026-07-31');
+      return new Response(
+        JSON.stringify({ range: { from: '', to: '' }, totals: {}, by_feature: [], daily: [] }),
+        { status: 200 },
+      );
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+    await client.getUsage({ from: '2026-07-01', to: '2026-07-31' });
+  });
+
+  it('rejects non-2xx responses with AiApiError including the parsed body', async () => {
+    const fetchImpl = mockFetch(() =>
+      new Response(JSON.stringify({ message: 'Validation failed.', errors: { api_key: ['Required.'] } }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+
+    await expect(client.updateSettings({ provider: 'openai' })).rejects.toMatchObject({
+      name: 'AiApiError',
+      status: 422,
+    });
+
+    try {
+      await client.updateSettings({ provider: 'openai' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(AiApiError);
+      expect((err as AiApiError).body).toMatchObject({ errors: { api_key: ['Required.'] } });
+    }
+  });
+
+  it('URL-encodes the feature key when toggling', async () => {
+    const fetchImpl = mockFetch((url, init) => {
+      expect(url).toBe('/api/artisanpack-ai/features/summarize.post/toggle');
+      expect(init?.method).toBe('POST');
+      return new Response(JSON.stringify({ feature: { key: 'summarize.post', package: 'core', enabled: true } }), {
+        status: 200,
+      });
+    });
+
+    const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai', fetchImpl });
+    await client.toggleFeature('summarize.post', true);
+  });
+});

--- a/packages/react/src/__tests__/ai/testClient.ts
+++ b/packages/react/src/__tests__/ai/testClient.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest';
+import type { AiApiClient } from '../../components/ai/types';
+
+/**
+ * Build a fully-mocked {@link AiApiClient} with vi.fn() implementations for each
+ * method. Callers override individual methods with `.mockResolvedValueOnce(...)`
+ * to script the responses their test needs.
+ */
+export function createMockClient(overrides: Partial<AiApiClient> = {}): AiApiClient {
+  return {
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+    testConnection: vi.fn(),
+    getFeatures: vi.fn(),
+    toggleFeature: vi.fn(),
+    getUsage: vi.fn(),
+    ...overrides,
+  } as AiApiClient;
+}

--- a/packages/react/src/components/ai/FeatureToggles/FeatureToggles.stories.tsx
+++ b/packages/react/src/components/ai/FeatureToggles/FeatureToggles.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FeatureToggles } from './FeatureToggles';
+import { createStorybookMockClient } from '../mockClient';
+
+const meta: Meta<typeof FeatureToggles> = {
+  title: 'AI/FeatureToggles',
+  component: FeatureToggles,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Per-feature enable/disable list backed by GET `/features` and POST `/features/{key}/toggle`.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FeatureToggles>;
+
+export const Default: Story = {
+  render: () => <FeatureToggles client={createStorybookMockClient()} heading="AI Features" />,
+};

--- a/packages/react/src/components/ai/FeatureToggles/FeatureToggles.tsx
+++ b/packages/react/src/components/ai/FeatureToggles/FeatureToggles.tsx
@@ -49,6 +49,7 @@ export function FeatureToggles({ client, heading, onToggle }: FeatureTogglesProp
       );
       try {
         const response = await client.toggleFeature(feature.key, target);
+        setError(null);
         onToggle?.(response.feature);
       } catch (err) {
         // Roll back on failure.
@@ -69,34 +70,45 @@ export function FeatureToggles({ client, heading, onToggle }: FeatureTogglesProp
     [client, onToggle],
   );
 
+  const headingNode = heading ? <h2 className="text-lg font-semibold">{heading}</h2> : null;
+
   if (error && !features) {
     return (
-      <div role="alert" className="alert alert-error">
-        <span>{error}</span>
+      <div className="flex flex-col gap-3">
+        {headingNode}
+        <div role="alert" className="alert alert-error">
+          <span>{error}</span>
+        </div>
       </div>
     );
   }
 
   if (!features) {
     return (
-      <div className="flex items-center gap-2" role="status" aria-live="polite">
-        <span className="loading loading-spinner loading-sm" aria-hidden="true" />
-        <span>Loading features…</span>
+      <div className="flex flex-col gap-3">
+        {headingNode}
+        <div className="flex items-center gap-2" role="status" aria-live="polite">
+          <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+          <span>Loading features…</span>
+        </div>
       </div>
     );
   }
 
   if (features.length === 0) {
     return (
-      <div className="text-sm text-base-content/70" role="status">
-        No AI features registered.
+      <div className="flex flex-col gap-3">
+        {headingNode}
+        <div className="text-sm text-base-content/70" role="status">
+          No AI features registered.
+        </div>
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-3" data-testid="ai-feature-toggles">
-      {heading ? <h2 className="text-lg font-semibold">{heading}</h2> : null}
+      {headingNode}
       {error ? (
         <div role="alert" className="alert alert-error">
           <span>{error}</span>

--- a/packages/react/src/components/ai/FeatureToggles/FeatureToggles.tsx
+++ b/packages/react/src/components/ai/FeatureToggles/FeatureToggles.tsx
@@ -1,0 +1,138 @@
+/** @module ai/FeatureToggles */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { AiApiClient, AiFeature } from '../types';
+
+/**
+ * Props for {@link FeatureToggles}.
+ */
+export interface FeatureTogglesProps {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Optional heading rendered above the list. */
+  heading?: string;
+  /** Callback fired after a successful toggle. */
+  onToggle?: (feature: Pick<AiFeature, 'key' | 'package' | 'enabled'>) => void;
+}
+
+/**
+ * Per-feature enable/disable list backed by GET `/features` and
+ * POST `/features/{key}/toggle`. Each row optimistically flips its own
+ * switch and rolls back on API failure.
+ */
+export function FeatureToggles({ client, heading, onToggle }: FeatureTogglesProps) {
+  const [features, setFeatures] = useState<AiFeature[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .getFeatures()
+      .then((response) => {
+        if (!cancelled) setFeatures(response.features);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const handleToggle = useCallback(
+    async (feature: AiFeature) => {
+      const target = !feature.enabled;
+      setPending((prev) => ({ ...prev, [feature.key]: true }));
+      setFeatures(
+        (prev) => prev?.map((f) => (f.key === feature.key ? { ...f, enabled: target } : f)) ?? prev,
+      );
+      try {
+        const response = await client.toggleFeature(feature.key, target);
+        onToggle?.(response.feature);
+      } catch (err) {
+        // Roll back on failure.
+        setFeatures(
+          (prev) =>
+            prev?.map((f) => (f.key === feature.key ? { ...f, enabled: feature.enabled } : f)) ??
+            prev,
+        );
+        setError((err as Error).message);
+      } finally {
+        setPending((prev) => {
+          const next = { ...prev };
+          delete next[feature.key];
+          return next;
+        });
+      }
+    },
+    [client, onToggle],
+  );
+
+  if (error && !features) {
+    return (
+      <div role="alert" className="alert alert-error">
+        <span>{error}</span>
+      </div>
+    );
+  }
+
+  if (!features) {
+    return (
+      <div className="flex items-center gap-2" role="status" aria-live="polite">
+        <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+        <span>Loading features…</span>
+      </div>
+    );
+  }
+
+  if (features.length === 0) {
+    return (
+      <div className="text-sm text-base-content/70" role="status">
+        No AI features registered.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="ai-feature-toggles">
+      {heading ? <h2 className="text-lg font-semibold">{heading}</h2> : null}
+      {error ? (
+        <div role="alert" className="alert alert-error">
+          <span>{error}</span>
+        </div>
+      ) : null}
+      <ul className="flex flex-col gap-2">
+        {features.map((feature) => (
+          <li
+            key={feature.key}
+            className="flex items-center justify-between gap-4 rounded-box border border-base-300 p-3"
+          >
+            <div className="flex flex-col">
+              <span className="font-medium">{feature.label}</span>
+              {feature.description ? (
+                <span className="text-sm text-base-content/70">{feature.description}</span>
+              ) : null}
+              <span className="text-xs uppercase tracking-wide text-base-content/50">
+                {feature.package} · {feature.key}
+              </span>
+            </div>
+            <label className="cursor-pointer">
+              <span className="sr-only">
+                {feature.enabled ? 'Disable' : 'Enable'} {feature.label}
+              </span>
+              <input
+                type="checkbox"
+                className="toggle toggle-primary"
+                checked={feature.enabled}
+                disabled={pending[feature.key] === true}
+                onChange={() => handleToggle(feature)}
+                aria-label={`Toggle ${feature.label}`}
+              />
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/react/src/components/ai/SettingsPage/SettingsPage.stories.tsx
+++ b/packages/react/src/components/ai/SettingsPage/SettingsPage.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SettingsPage } from './SettingsPage';
+import { createStorybookMockClient } from '../mockClient';
+
+const meta: Meta<typeof SettingsPage> = {
+  title: 'AI/SettingsPage',
+  component: SettingsPage,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Admin form backed by the artisanpack-ui/ai settings JSON API. Handles provider credentials, per-feature overrides, and a `test-connection` probe.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SettingsPage>;
+
+export const Default: Story = {
+  render: () => <SettingsPage client={createStorybookMockClient()} heading="AI Settings" />,
+};

--- a/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
+++ b/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
@@ -198,9 +198,7 @@ export function SettingsPage({
         <div
           role="status"
           aria-live="polite"
-          className={
-            Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'
-          }
+          className={Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'}
         >
           <span>{status}</span>
         </div>
@@ -251,9 +249,7 @@ export function SettingsPage({
         ) : null}
 
         <label className="form-control flex flex-col gap-1">
-          <span className="label-text">
-            Base URL {isOllama ? '(required)' : '(optional)'}
-          </span>
+          <span className="label-text">Base URL {isOllama ? '(required)' : '(optional)'}</span>
           <input
             type="url"
             className="input input-bordered"
@@ -296,9 +292,7 @@ export function SettingsPage({
           {testResult ? (
             <span
               role="status"
-              className={
-                testResult.result === 'ok' ? 'text-sm text-success' : 'text-sm text-error'
-              }
+              className={testResult.result === 'ok' ? 'text-sm text-success' : 'text-sm text-error'}
             >
               {testResult.message ?? (testResult.result === 'ok' ? 'OK' : 'Failed')}
             </span>
@@ -312,10 +306,7 @@ export function SettingsPage({
           {form.overrides.map((override) => {
             const current = overrideByKey.get(override.feature_key) ?? override;
             return (
-              <div
-                key={override.feature_key}
-                className="rounded-box border border-base-300 p-3"
-              >
+              <div key={override.feature_key} className="rounded-box border border-base-300 p-3">
                 <div className="text-sm font-medium">
                   {override.package} · {override.feature_key}
                 </div>

--- a/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
+++ b/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,6 @@
 /** @module ai/SettingsPage */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type {
   AiApiClient,
   AiConnectionTestResult,
@@ -81,6 +81,7 @@ export function SettingsPage({
   const [testing, setTesting] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const [status, setStatus] = useState<string | null>(null);
+  const [statusVariant, setStatusVariant] = useState<'success' | 'error'>('success');
   const [testResult, setTestResult] = useState<AiConnectionTestResult | null>(null);
 
   useEffect(() => {
@@ -94,7 +95,9 @@ export function SettingsPage({
         setForm(toFormState(response));
       })
       .catch((err: Error) => {
-        if (!cancelled) setStatus(err.message);
+        if (cancelled) return;
+        setStatus(err.message);
+        setStatusVariant('error');
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -107,13 +110,12 @@ export function SettingsPage({
   const apiKeyPresent = initial?.credentials.api_key_present ?? false;
   const isOllama = form.provider === 'ollama';
 
-  const overrideByKey = useMemo(() => {
-    const map = new Map<string, AiFeatureOverride>();
-    for (const override of form.overrides) {
-      map.set(override.feature_key, override);
-    }
-    return map;
-  }, [form.overrides]);
+  const handleProviderChange = useCallback((provider: string) => {
+    // Reset the typed key + last probe result so we don't silently ship
+    // an OpenAI key to an Ollama base URL (or the other way around).
+    setForm((prev) => ({ ...prev, provider, api_key: '' }));
+    setTestResult(null);
+  }, []);
 
   const updateOverride = useCallback(
     (key: string, patch: Partial<Pick<AiFeatureOverride, 'model' | 'instructions'>>) => {
@@ -138,7 +140,9 @@ export function SettingsPage({
         setInitial(response);
         setForm(toFormState(response));
         setStatus('Settings saved.');
+        setStatusVariant('success');
       } catch (err) {
+        setStatusVariant('error');
         if (err instanceof AiApiError && err.status === 422) {
           const body = err.body as { errors?: FormErrors; message?: string };
           setErrors(body?.errors ?? {});
@@ -196,9 +200,9 @@ export function SettingsPage({
 
       {status ? (
         <div
-          role="status"
+          role={statusVariant === 'error' ? 'alert' : 'status'}
           aria-live="polite"
-          className={Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'}
+          className={statusVariant === 'error' ? 'alert alert-error' : 'alert alert-success'}
         >
           <span>{status}</span>
         </div>
@@ -212,7 +216,7 @@ export function SettingsPage({
           <select
             className="select select-bordered"
             value={form.provider}
-            onChange={(e) => setForm((prev) => ({ ...prev, provider: e.target.value }))}
+            onChange={(e) => handleProviderChange(e.target.value)}
           >
             {providers.map((provider) => (
               <option key={provider} value={provider}>
@@ -303,43 +307,40 @@ export function SettingsPage({
       {form.overrides.length > 0 ? (
         <fieldset className="flex flex-col gap-3">
           <legend className="text-base font-medium">Per-feature overrides</legend>
-          {form.overrides.map((override) => {
-            const current = overrideByKey.get(override.feature_key) ?? override;
-            return (
-              <div key={override.feature_key} className="rounded-box border border-base-300 p-3">
-                <div className="text-sm font-medium">
-                  {override.package} · {override.feature_key}
-                </div>
-                <label className="form-control mt-2 flex flex-col gap-1">
-                  <span className="label-text">Model</span>
-                  <input
-                    type="text"
-                    className="input input-bordered input-sm"
-                    value={current.model ?? ''}
-                    onChange={(e) =>
-                      updateOverride(override.feature_key, {
-                        model: e.target.value === '' ? null : e.target.value,
-                      })
-                    }
-                    placeholder="inherit default"
-                  />
-                </label>
-                <label className="form-control mt-2 flex flex-col gap-1">
-                  <span className="label-text">Instructions</span>
-                  <textarea
-                    className="textarea textarea-bordered"
-                    rows={3}
-                    value={current.instructions ?? ''}
-                    onChange={(e) =>
-                      updateOverride(override.feature_key, {
-                        instructions: e.target.value === '' ? null : e.target.value,
-                      })
-                    }
-                  />
-                </label>
+          {form.overrides.map((override) => (
+            <div key={override.feature_key} className="rounded-box border border-base-300 p-3">
+              <div className="text-sm font-medium">
+                {override.package} · {override.feature_key}
               </div>
-            );
-          })}
+              <label className="form-control mt-2 flex flex-col gap-1">
+                <span className="label-text">Model</span>
+                <input
+                  type="text"
+                  className="input input-bordered input-sm"
+                  value={override.model ?? ''}
+                  onChange={(e) =>
+                    updateOverride(override.feature_key, {
+                      model: e.target.value === '' ? null : e.target.value,
+                    })
+                  }
+                  placeholder="inherit default"
+                />
+              </label>
+              <label className="form-control mt-2 flex flex-col gap-1">
+                <span className="label-text">Instructions</span>
+                <textarea
+                  className="textarea textarea-bordered"
+                  rows={3}
+                  value={override.instructions ?? ''}
+                  onChange={(e) =>
+                    updateOverride(override.feature_key, {
+                      instructions: e.target.value === '' ? null : e.target.value,
+                    })
+                  }
+                />
+              </label>
+            </div>
+          ))}
         </fieldset>
       ) : null}
 

--- a/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
+++ b/packages/react/src/components/ai/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,362 @@
+/** @module ai/SettingsPage */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  AiApiClient,
+  AiConnectionTestResult,
+  AiFeatureOverride,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+} from '../types';
+import { AiApiError } from '../createAiApiClient';
+
+/**
+ * Props for {@link SettingsPage}.
+ */
+export interface SettingsPageProps {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Provider IDs shown in the provider dropdown. */
+  providers?: string[];
+  /** Optional heading rendered above the form. */
+  heading?: string;
+}
+
+type FormErrors = Record<string, string[]>;
+
+interface FormState {
+  provider: string;
+  api_key: string;
+  base_url: string;
+  default_model: string;
+  overrides: AiFeatureOverride[];
+}
+
+const emptyForm: FormState = {
+  provider: 'openai',
+  api_key: '',
+  base_url: '',
+  default_model: '',
+  overrides: [],
+};
+
+function toFormState(response: AiSettingsResponse): FormState {
+  return {
+    provider: response.credentials.provider,
+    api_key: '',
+    base_url: response.credentials.base_url ?? '',
+    default_model: response.credentials.default_model ?? '',
+    overrides: response.feature_overrides,
+  };
+}
+
+function toUpdatePayload(form: FormState): AiSettingsUpdate {
+  return {
+    provider: form.provider,
+    api_key: form.api_key === '' ? null : form.api_key,
+    base_url: form.base_url === '' ? null : form.base_url,
+    default_model: form.default_model === '' ? null : form.default_model,
+    feature_overrides: form.overrides.map((override) => ({
+      feature_key: override.feature_key,
+      model: override.model,
+      instructions: override.instructions,
+    })),
+  };
+}
+
+/**
+ * Admin form backed by GET/PUT `/settings` and POST `/test-connection`.
+ * Renders provider credentials, per-feature model/instruction overrides,
+ * and a probe button that surfaces `test-connection` results inline.
+ */
+export function SettingsPage({
+  client,
+  providers = ['openai', 'anthropic', 'ollama'],
+  heading,
+}: SettingsPageProps) {
+  const [initial, setInitial] = useState<AiSettingsResponse | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<AiConnectionTestResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    client
+      .getSettings()
+      .then((response) => {
+        if (cancelled) return;
+        setInitial(response);
+        setForm(toFormState(response));
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setStatus(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const apiKeyPresent = initial?.credentials.api_key_present ?? false;
+  const isOllama = form.provider === 'ollama';
+
+  const overrideByKey = useMemo(() => {
+    const map = new Map<string, AiFeatureOverride>();
+    for (const override of form.overrides) {
+      map.set(override.feature_key, override);
+    }
+    return map;
+  }, [form.overrides]);
+
+  const updateOverride = useCallback(
+    (key: string, patch: Partial<Pick<AiFeatureOverride, 'model' | 'instructions'>>) => {
+      setForm((prev) => ({
+        ...prev,
+        overrides: prev.overrides.map((override) =>
+          override.feature_key === key ? { ...override, ...patch } : override,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      setSaving(true);
+      setErrors({});
+      setStatus(null);
+      try {
+        const response = await client.updateSettings(toUpdatePayload(form));
+        setInitial(response);
+        setForm(toFormState(response));
+        setStatus('Settings saved.');
+      } catch (err) {
+        if (err instanceof AiApiError && err.status === 422) {
+          const body = err.body as { errors?: FormErrors; message?: string };
+          setErrors(body?.errors ?? {});
+          setStatus(body?.message ?? err.message);
+        } else {
+          setStatus((err as Error).message);
+        }
+      } finally {
+        setSaving(false);
+      }
+    },
+    [client, form],
+  );
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await client.testConnection({
+        provider: form.provider,
+        api_key: form.api_key === '' ? null : form.api_key,
+        base_url: form.base_url === '' ? null : form.base_url,
+        default_model: form.default_model === '' ? null : form.default_model,
+      });
+      setTestResult(result);
+    } catch (err) {
+      if (err instanceof AiApiError) {
+        const body = err.body as AiConnectionTestResult | null;
+        setTestResult(body ?? { result: 'error', message: err.message });
+      } else {
+        setTestResult({ result: 'error', message: (err as Error).message });
+      }
+    } finally {
+      setTesting(false);
+    }
+  }, [client, form.api_key, form.base_url, form.default_model, form.provider]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2" role="status" aria-live="polite">
+        <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+        <span>Loading AI settings…</span>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-6"
+      data-testid="ai-settings-page"
+      noValidate
+    >
+      {heading ? <h2 className="text-lg font-semibold">{heading}</h2> : null}
+
+      {status ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className={
+            Object.keys(errors).length > 0 ? 'alert alert-error' : 'alert alert-success'
+          }
+        >
+          <span>{status}</span>
+        </div>
+      ) : null}
+
+      <fieldset className="flex flex-col gap-3">
+        <legend className="text-base font-medium">Credentials</legend>
+
+        <label className="form-control flex flex-col gap-1">
+          <span className="label-text">Provider</span>
+          <select
+            className="select select-bordered"
+            value={form.provider}
+            onChange={(e) => setForm((prev) => ({ ...prev, provider: e.target.value }))}
+          >
+            {providers.map((provider) => (
+              <option key={provider} value={provider}>
+                {provider}
+              </option>
+            ))}
+          </select>
+          {errors.provider?.map((message) => (
+            <span key={message} className="label-text-alt text-error">
+              {message}
+            </span>
+          ))}
+        </label>
+
+        {!isOllama ? (
+          <label className="form-control flex flex-col gap-1">
+            <span className="label-text">
+              API key {apiKeyPresent ? '(leave blank to keep the stored key)' : ''}
+            </span>
+            <input
+              type="password"
+              autoComplete="off"
+              className="input input-bordered"
+              value={form.api_key}
+              onChange={(e) => setForm((prev) => ({ ...prev, api_key: e.target.value }))}
+              placeholder={apiKeyPresent ? '••••••••' : 'sk-…'}
+            />
+            {errors.api_key?.map((message) => (
+              <span key={message} className="label-text-alt text-error">
+                {message}
+              </span>
+            ))}
+          </label>
+        ) : null}
+
+        <label className="form-control flex flex-col gap-1">
+          <span className="label-text">
+            Base URL {isOllama ? '(required)' : '(optional)'}
+          </span>
+          <input
+            type="url"
+            className="input input-bordered"
+            value={form.base_url}
+            onChange={(e) => setForm((prev) => ({ ...prev, base_url: e.target.value }))}
+            placeholder={isOllama ? 'http://localhost:11434' : 'https://api.example.com/v1'}
+          />
+          {errors.base_url?.map((message) => (
+            <span key={message} className="label-text-alt text-error">
+              {message}
+            </span>
+          ))}
+        </label>
+
+        <label className="form-control flex flex-col gap-1">
+          <span className="label-text">Default model</span>
+          <input
+            type="text"
+            className="input input-bordered"
+            value={form.default_model}
+            onChange={(e) => setForm((prev) => ({ ...prev, default_model: e.target.value }))}
+            placeholder="gpt-4o-mini"
+          />
+          {errors.default_model?.map((message) => (
+            <span key={message} className="label-text-alt text-error">
+              {message}
+            </span>
+          ))}
+        </label>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-outline btn-sm"
+            onClick={handleTest}
+            disabled={testing}
+          >
+            {testing ? 'Testing…' : 'Test connection'}
+          </button>
+          {testResult ? (
+            <span
+              role="status"
+              className={
+                testResult.result === 'ok' ? 'text-sm text-success' : 'text-sm text-error'
+              }
+            >
+              {testResult.message ?? (testResult.result === 'ok' ? 'OK' : 'Failed')}
+            </span>
+          ) : null}
+        </div>
+      </fieldset>
+
+      {form.overrides.length > 0 ? (
+        <fieldset className="flex flex-col gap-3">
+          <legend className="text-base font-medium">Per-feature overrides</legend>
+          {form.overrides.map((override) => {
+            const current = overrideByKey.get(override.feature_key) ?? override;
+            return (
+              <div
+                key={override.feature_key}
+                className="rounded-box border border-base-300 p-3"
+              >
+                <div className="text-sm font-medium">
+                  {override.package} · {override.feature_key}
+                </div>
+                <label className="form-control mt-2 flex flex-col gap-1">
+                  <span className="label-text">Model</span>
+                  <input
+                    type="text"
+                    className="input input-bordered input-sm"
+                    value={current.model ?? ''}
+                    onChange={(e) =>
+                      updateOverride(override.feature_key, {
+                        model: e.target.value === '' ? null : e.target.value,
+                      })
+                    }
+                    placeholder="inherit default"
+                  />
+                </label>
+                <label className="form-control mt-2 flex flex-col gap-1">
+                  <span className="label-text">Instructions</span>
+                  <textarea
+                    className="textarea textarea-bordered"
+                    rows={3}
+                    value={current.instructions ?? ''}
+                    onChange={(e) =>
+                      updateOverride(override.feature_key, {
+                        instructions: e.target.value === '' ? null : e.target.value,
+                      })
+                    }
+                  />
+                </label>
+              </div>
+            );
+          })}
+        </fieldset>
+      ) : null}
+
+      <div className="flex justify-end">
+        <button type="submit" className="btn btn-primary" disabled={saving}>
+          {saving ? 'Saving…' : 'Save settings'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/react/src/components/ai/UsageDashboard/UsageDashboard.stories.tsx
+++ b/packages/react/src/components/ai/UsageDashboard/UsageDashboard.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { UsageDashboard } from './UsageDashboard';
+import { createStorybookMockClient } from '../mockClient';
+
+const meta: Meta<typeof UsageDashboard> = {
+  title: 'AI/UsageDashboard',
+  component: UsageDashboard,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Aggregated usage dashboard backed by GET `/usage`. Set `refreshInterval` (ms) to enable polling for live updates.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UsageDashboard>;
+
+export const Default: Story = {
+  render: () => <UsageDashboard client={createStorybookMockClient()} heading="AI Usage" />,
+};
+
+export const Live: Story = {
+  name: 'Live (polling)',
+  render: () => (
+    <UsageDashboard client={createStorybookMockClient()} refreshInterval={5000} heading="AI Usage" />
+  ),
+};

--- a/packages/react/src/components/ai/UsageDashboard/UsageDashboard.stories.tsx
+++ b/packages/react/src/components/ai/UsageDashboard/UsageDashboard.stories.tsx
@@ -27,6 +27,10 @@ export const Default: Story = {
 export const Live: Story = {
   name: 'Live (polling)',
   render: () => (
-    <UsageDashboard client={createStorybookMockClient()} refreshInterval={5000} heading="AI Usage" />
+    <UsageDashboard
+      client={createStorybookMockClient()}
+      refreshInterval={5000}
+      heading="AI Usage"
+    />
   ),
 };

--- a/packages/react/src/components/ai/UsageDashboard/UsageDashboard.tsx
+++ b/packages/react/src/components/ai/UsageDashboard/UsageDashboard.tsx
@@ -52,20 +52,22 @@ export function UsageDashboard({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
+  const requestSeqRef = useRef(0);
 
   const load = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     try {
       const response = await client.getUsage({ from, to });
-      if (!cancelledRef.current) {
-        setUsage(response);
-        setError(null);
-      }
+      // Discard responses that lost the race to a newer request — otherwise
+      // a slow-poll response can clobber a fresher one under high latency.
+      if (cancelledRef.current || seq !== requestSeqRef.current) return;
+      setUsage(response);
+      setError(null);
     } catch (err) {
-      if (!cancelledRef.current) {
-        setError((err as Error).message);
-      }
+      if (cancelledRef.current || seq !== requestSeqRef.current) return;
+      setError((err as Error).message);
     } finally {
-      if (!cancelledRef.current) {
+      if (!cancelledRef.current && seq === requestSeqRef.current) {
         setLoading(false);
       }
     }

--- a/packages/react/src/components/ai/UsageDashboard/UsageDashboard.tsx
+++ b/packages/react/src/components/ai/UsageDashboard/UsageDashboard.tsx
@@ -1,0 +1,209 @@
+/** @module ai/UsageDashboard */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AiApiClient, AiUsageResponse } from '../types';
+
+/**
+ * Props for {@link UsageDashboard}.
+ */
+export interface UsageDashboardProps {
+  /** API client wrapping the artisanpack-ui/ai JSON endpoints. */
+  client: AiApiClient;
+  /** Optional `from` date (YYYY-MM-DD) passed as a query param. */
+  from?: string;
+  /** Optional `to` date (YYYY-MM-DD) passed as a query param. */
+  to?: string;
+  /**
+   * Poll interval in milliseconds for live updates. Defaults to `0` (no polling).
+   * Set to `15000` for a 15-second refresh — the underlying `/usage` endpoint
+   * is cheap enough for this and mirrors the Livewire dashboard cadence.
+   */
+  refreshInterval?: number;
+  /** Optional heading rendered above the dashboard. */
+  heading?: string;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatCost(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(value);
+}
+
+/**
+ * Aggregated dashboard fed by GET `/usage`. Renders totals, per-feature
+ * breakdown, and daily buckets, with optional polling for live updates
+ * via {@link UsageDashboardProps.refreshInterval}.
+ */
+export function UsageDashboard({
+  client,
+  from,
+  to,
+  refreshInterval = 0,
+  heading,
+}: UsageDashboardProps) {
+  const [usage, setUsage] = useState<AiUsageResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await client.getUsage({ from, to });
+      if (!cancelledRef.current) {
+        setUsage(response);
+        setError(null);
+      }
+    } catch (err) {
+      if (!cancelledRef.current) {
+        setError((err as Error).message);
+      }
+    } finally {
+      if (!cancelledRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [client, from, to]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    setLoading(true);
+    load();
+
+    if (refreshInterval > 0) {
+      const id = setInterval(load, refreshInterval);
+      return () => {
+        cancelledRef.current = true;
+        clearInterval(id);
+      };
+    }
+
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [load, refreshInterval]);
+
+  if (loading && !usage) {
+    return (
+      <div className="flex items-center gap-2" role="status" aria-live="polite">
+        <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+        <span>Loading usage…</span>
+      </div>
+    );
+  }
+
+  if (error && !usage) {
+    return (
+      <div role="alert" className="alert alert-error">
+        <span>{error}</span>
+      </div>
+    );
+  }
+
+  if (!usage) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="ai-usage-dashboard">
+      {heading ? <h2 className="text-lg font-semibold">{heading}</h2> : null}
+
+      <div className="stats stats-vertical sm:stats-horizontal shadow">
+        <div className="stat">
+          <div className="stat-title">Requests</div>
+          <div className="stat-value">{formatNumber(usage.totals.requests)}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Input tokens</div>
+          <div className="stat-value">{formatNumber(usage.totals.input_tokens)}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Output tokens</div>
+          <div className="stat-value">{formatNumber(usage.totals.output_tokens)}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Cost</div>
+          <div className="stat-value">{formatCost(usage.totals.cost)}</div>
+        </div>
+      </div>
+
+      <section aria-labelledby="ai-usage-by-feature">
+        <h3 id="ai-usage-by-feature" className="mb-2 font-medium">
+          By feature
+        </h3>
+        {usage.by_feature.length === 0 ? (
+          <p className="text-sm text-base-content/70">No feature usage in this range.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="table table-sm">
+              <thead>
+                <tr>
+                  <th>Feature</th>
+                  <th className="text-right">Requests</th>
+                  <th className="text-right">Input</th>
+                  <th className="text-right">Output</th>
+                  <th className="text-right">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usage.by_feature.map((row) => (
+                  <tr key={row.feature_key}>
+                    <td>{row.feature_key}</td>
+                    <td className="text-right">{formatNumber(row.requests)}</td>
+                    <td className="text-right">{formatNumber(row.input_tokens)}</td>
+                    <td className="text-right">{formatNumber(row.output_tokens)}</td>
+                    <td className="text-right">{formatCost(row.cost)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section aria-labelledby="ai-usage-daily">
+        <h3 id="ai-usage-daily" className="mb-2 font-medium">
+          Daily
+        </h3>
+        {usage.daily.length === 0 ? (
+          <p className="text-sm text-base-content/70">No daily usage in this range.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="table table-sm">
+              <thead>
+                <tr>
+                  <th>Day</th>
+                  <th className="text-right">Requests</th>
+                  <th className="text-right">Tokens</th>
+                  <th className="text-right">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usage.daily.map((row) => (
+                  <tr key={row.period}>
+                    <td>{row.period}</td>
+                    <td className="text-right">{formatNumber(row.requests)}</td>
+                    <td className="text-right">{formatNumber(row.total_tokens)}</td>
+                    <td className="text-right">{formatCost(row.cost)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {refreshInterval > 0 ? (
+        <p className="text-xs text-base-content/50" role="status" aria-live="polite">
+          Live · refreshing every {Math.round(refreshInterval / 1000)}s
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react/src/components/ai/createAiApiClient.ts
+++ b/packages/react/src/components/ai/createAiApiClient.ts
@@ -56,7 +56,9 @@ export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClien
     const search = query
       ? '?' +
         new URLSearchParams(
-          Object.entries(query).flatMap(([k, v]) => (v == null ? [] : [[k, v] as [string, string]])),
+          Object.entries(query).flatMap(([k, v]) =>
+            v == null ? [] : [[k, v] as [string, string]],
+          ),
         ).toString()
       : '';
     const response = await doFetch(`${trimmedBase}${path}${search}`, {

--- a/packages/react/src/components/ai/createAiApiClient.ts
+++ b/packages/react/src/components/ai/createAiApiClient.ts
@@ -1,0 +1,117 @@
+/** @module ai/createAiApiClient */
+
+import type {
+  AiApiClient,
+  AiConnectionTestResult,
+  AiFeature,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+  AiUsageResponse,
+} from './types';
+
+/**
+ * Options for {@link createAiApiClient}.
+ */
+export interface CreateAiApiClientOptions {
+  /** Base URL of the AI JSON API, e.g. `'/api/artisanpack-ai'`. */
+  baseUrl: string;
+  /** Optional `fetch` override (for tests or custom auth wrappers). */
+  fetchImpl?: typeof fetch;
+  /** Extra headers merged into every request (e.g. `{ 'X-CSRF-TOKEN': token }`). */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Thrown when the AI API returns a non-2xx response. Includes the parsed body
+ * so consumers can surface validation errors returned as `{ errors: ... }`.
+ */
+export class AiApiError extends Error {
+  public readonly status: number;
+  public readonly body: unknown;
+
+  constructor(status: number, body: unknown, message: string) {
+    super(message);
+    this.name = 'AiApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Create a small {@link AiApiClient} that wraps `fetch` calls to the
+ * artisanpack-ui/ai JSON API endpoints. Non-2xx responses reject with
+ * {@link AiApiError}.
+ */
+export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClient {
+  const { baseUrl, fetchImpl, headers: extraHeaders } = options;
+  const doFetch = fetchImpl ?? globalThis.fetch;
+
+  const trimmedBase = baseUrl.replace(/\/$/, '');
+
+  async function request<T>(
+    path: string,
+    init: RequestInit = {},
+    query?: Record<string, string | undefined>,
+  ): Promise<T> {
+    const search = query
+      ? '?' +
+        new URLSearchParams(
+          Object.entries(query).flatMap(([k, v]) => (v == null ? [] : [[k, v] as [string, string]])),
+        ).toString()
+      : '';
+    const response = await doFetch(`${trimmedBase}${path}${search}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...extraHeaders,
+        ...init.headers,
+      },
+    });
+
+    const raw = await response.text();
+    let body: unknown = null;
+    if (raw.length > 0) {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        body = raw;
+      }
+    }
+
+    if (!response.ok) {
+      const message =
+        (body && typeof body === 'object' && 'message' in body && typeof body.message === 'string'
+          ? body.message
+          : null) ?? `AI API request to ${path} failed with status ${response.status}`;
+      throw new AiApiError(response.status, body, message);
+    }
+
+    return body as T;
+  }
+
+  return {
+    getSettings: () => request<AiSettingsResponse>('/settings'),
+    updateSettings: (body: AiSettingsUpdate) =>
+      request<AiSettingsResponse>('/settings', {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
+    testConnection: (body) =>
+      request<AiConnectionTestResult>('/test-connection', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    getFeatures: () => request<{ features: AiFeature[] }>('/features'),
+    toggleFeature: (key: string, enabled?: boolean) =>
+      request<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>(
+        `/features/${encodeURIComponent(key)}/toggle`,
+        {
+          method: 'POST',
+          body: JSON.stringify(enabled === undefined ? {} : { enabled }),
+        },
+      ),
+    getUsage: (params) =>
+      request<AiUsageResponse>('/usage', {}, { from: params?.from, to: params?.to }),
+  };
+}

--- a/packages/react/src/components/ai/createAiApiClient.ts
+++ b/packages/react/src/components/ai/createAiApiClient.ts
@@ -53,19 +53,23 @@ export function createAiApiClient(options: CreateAiApiClientOptions): AiApiClien
     init: RequestInit = {},
     query?: Record<string, string | undefined>,
   ): Promise<T> {
-    const search = query
-      ? '?' +
-        new URLSearchParams(
+    const searchParams = query
+      ? new URLSearchParams(
           Object.entries(query).flatMap(([k, v]) =>
             v == null ? [] : [[k, v] as [string, string]],
           ),
         ).toString()
       : '';
+    const search = searchParams === '' ? '' : `?${searchParams}`;
+    // Only advertise a JSON request body on methods that actually carry one —
+    // strict reverse-proxies and Sanctum form-request configs reject GET/DELETE
+    // requests that ship a Content-Type without a body.
+    const hasBody = init.body != null;
     const response = await doFetch(`${trimmedBase}${path}${search}`, {
       ...init,
       headers: {
         Accept: 'application/json',
-        'Content-Type': 'application/json',
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
         ...extraHeaders,
         ...init.headers,
       },

--- a/packages/react/src/components/ai/index.ts
+++ b/packages/react/src/components/ai/index.ts
@@ -1,0 +1,47 @@
+/**
+ * @module ai
+ *
+ * React components + hooks for consuming the artisanpack-ui/ai JSON API.
+ * Shipped as the `@artisanpack-ui/react/ai` subpath.
+ *
+ * @example
+ * ```tsx
+ * import { createAiApiClient, SettingsPage, UsageDashboard, FeatureToggles } from '@artisanpack-ui/react/ai';
+ *
+ * const client = createAiApiClient({ baseUrl: '/api/artisanpack-ai' });
+ *
+ * <SettingsPage client={client} heading="AI Settings" />
+ * <UsageDashboard client={client} refreshInterval={15_000} />
+ * <FeatureToggles client={client} heading="AI Features" />
+ * ```
+ */
+
+export { SettingsPage } from './SettingsPage/SettingsPage';
+export type { SettingsPageProps } from './SettingsPage/SettingsPage';
+
+export { UsageDashboard } from './UsageDashboard/UsageDashboard';
+export type { UsageDashboardProps } from './UsageDashboard/UsageDashboard';
+
+export { FeatureToggles } from './FeatureToggles/FeatureToggles';
+export type { FeatureTogglesProps } from './FeatureToggles/FeatureToggles';
+
+export { createAiApiClient, AiApiError } from './createAiApiClient';
+export type { CreateAiApiClientOptions } from './createAiApiClient';
+
+export { useStreamingText } from './useStreamingText';
+export type { UseStreamingTextResult } from './useStreamingText';
+
+export type {
+  AiApiClient,
+  AiCredentials,
+  AiFeature,
+  AiFeatureOverride,
+  AiSettingsResponse,
+  AiSettingsUpdate,
+  AiConnectionTestResult,
+  AiUsageTotals,
+  AiUsageByFeature,
+  AiUsageDaily,
+  AiUsageResponse,
+  AiValidationError,
+} from './types';

--- a/packages/react/src/components/ai/mockClient.ts
+++ b/packages/react/src/components/ai/mockClient.ts
@@ -1,0 +1,75 @@
+/** @module ai/mockClient */
+
+import type { AiApiClient, AiSettingsResponse, AiUsageResponse, AiFeature } from './types';
+
+/**
+ * In-memory {@link AiApiClient} for Storybook stories and demos. All methods
+ * resolve after a short delay so loading states are visible.
+ *
+ * @internal
+ */
+export function createStorybookMockClient(): AiApiClient {
+  let settings: AiSettingsResponse = {
+    credentials: {
+      provider: 'openai',
+      api_key_present: true,
+      base_url: null,
+      default_model: 'gpt-4o-mini',
+    },
+    feature_overrides: [
+      { feature_key: 'summarize', package: 'core', model: null, instructions: null },
+      { feature_key: 'chat', package: 'core', model: 'gpt-4o', instructions: 'Be concise.' },
+    ],
+  };
+
+  let features: AiFeature[] = [
+    { key: 'summarize', package: 'core', label: 'Summarize', description: 'AI-generated summaries', enabled: true },
+    { key: 'chat', package: 'core', label: 'Chat', description: 'Assistant chat surface', enabled: false },
+  ];
+
+  const usage: AiUsageResponse = {
+    range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
+    totals: { requests: 42, input_tokens: 12_000, output_tokens: 4_800, total_tokens: 16_800, cost: 1.24 },
+    by_feature: [
+      { feature_key: 'summarize', requests: 30, input_tokens: 9_000, output_tokens: 3_000, total_tokens: 12_000, cost: 0.9 },
+      { feature_key: 'chat', requests: 12, input_tokens: 3_000, output_tokens: 1_800, total_tokens: 4_800, cost: 0.34 },
+    ],
+    daily: [
+      { period: '2026-07-04', requests: 20, input_tokens: 6_000, output_tokens: 2_000, total_tokens: 8_000, cost: 0.6 },
+      { period: '2026-07-05', requests: 22, input_tokens: 6_000, output_tokens: 2_800, total_tokens: 8_800, cost: 0.64 },
+    ],
+  };
+
+  const delay = <T,>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
+
+  return {
+    getSettings: () => delay(settings),
+    updateSettings: (body) => {
+      settings = {
+        credentials: {
+          provider: body.provider,
+          api_key_present: settings.credentials.api_key_present || !!body.api_key,
+          base_url: body.base_url ?? null,
+          default_model: body.default_model ?? null,
+        },
+        feature_overrides:
+          body.feature_overrides?.map((row) => ({
+            feature_key: row.feature_key,
+            package: settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ?? 'core',
+            model: row.model ?? null,
+            instructions: row.instructions ?? null,
+          })) ?? settings.feature_overrides,
+      };
+      return delay(settings);
+    },
+    testConnection: (body) =>
+      delay({ result: 'ok' as const, message: `Connected to ${body.provider}`, provider: body.provider }),
+    getFeatures: () => delay({ features }),
+    toggleFeature: (key, enabled) => {
+      features = features.map((f) => (f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f));
+      const updated = features.find((f) => f.key === key)!;
+      return delay({ feature: { key: updated.key, package: updated.package, enabled: updated.enabled } });
+    },
+    getUsage: () => delay(usage),
+  };
+}

--- a/packages/react/src/components/ai/mockClient.ts
+++ b/packages/react/src/components/ai/mockClient.ts
@@ -23,24 +23,70 @@ export function createStorybookMockClient(): AiApiClient {
   };
 
   let features: AiFeature[] = [
-    { key: 'summarize', package: 'core', label: 'Summarize', description: 'AI-generated summaries', enabled: true },
-    { key: 'chat', package: 'core', label: 'Chat', description: 'Assistant chat surface', enabled: false },
+    {
+      key: 'summarize',
+      package: 'core',
+      label: 'Summarize',
+      description: 'AI-generated summaries',
+      enabled: true,
+    },
+    {
+      key: 'chat',
+      package: 'core',
+      label: 'Chat',
+      description: 'Assistant chat surface',
+      enabled: false,
+    },
   ];
 
   const usage: AiUsageResponse = {
     range: { from: '2026-07-01T00:00:00+00:00', to: '2026-07-31T23:59:59+00:00' },
-    totals: { requests: 42, input_tokens: 12_000, output_tokens: 4_800, total_tokens: 16_800, cost: 1.24 },
+    totals: {
+      requests: 42,
+      input_tokens: 12_000,
+      output_tokens: 4_800,
+      total_tokens: 16_800,
+      cost: 1.24,
+    },
     by_feature: [
-      { feature_key: 'summarize', requests: 30, input_tokens: 9_000, output_tokens: 3_000, total_tokens: 12_000, cost: 0.9 },
-      { feature_key: 'chat', requests: 12, input_tokens: 3_000, output_tokens: 1_800, total_tokens: 4_800, cost: 0.34 },
+      {
+        feature_key: 'summarize',
+        requests: 30,
+        input_tokens: 9_000,
+        output_tokens: 3_000,
+        total_tokens: 12_000,
+        cost: 0.9,
+      },
+      {
+        feature_key: 'chat',
+        requests: 12,
+        input_tokens: 3_000,
+        output_tokens: 1_800,
+        total_tokens: 4_800,
+        cost: 0.34,
+      },
     ],
     daily: [
-      { period: '2026-07-04', requests: 20, input_tokens: 6_000, output_tokens: 2_000, total_tokens: 8_000, cost: 0.6 },
-      { period: '2026-07-05', requests: 22, input_tokens: 6_000, output_tokens: 2_800, total_tokens: 8_800, cost: 0.64 },
+      {
+        period: '2026-07-04',
+        requests: 20,
+        input_tokens: 6_000,
+        output_tokens: 2_000,
+        total_tokens: 8_000,
+        cost: 0.6,
+      },
+      {
+        period: '2026-07-05',
+        requests: 22,
+        input_tokens: 6_000,
+        output_tokens: 2_800,
+        total_tokens: 8_800,
+        cost: 0.64,
+      },
     ],
   };
 
-  const delay = <T,>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
+  const delay = <T>(value: T) => new Promise<T>((resolve) => setTimeout(() => resolve(value), 200));
 
   return {
     getSettings: () => delay(settings),
@@ -55,7 +101,9 @@ export function createStorybookMockClient(): AiApiClient {
         feature_overrides:
           body.feature_overrides?.map((row) => ({
             feature_key: row.feature_key,
-            package: settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ?? 'core',
+            package:
+              settings.feature_overrides.find((o) => o.feature_key === row.feature_key)?.package ??
+              'core',
             model: row.model ?? null,
             instructions: row.instructions ?? null,
           })) ?? settings.feature_overrides,
@@ -63,12 +111,20 @@ export function createStorybookMockClient(): AiApiClient {
       return delay(settings);
     },
     testConnection: (body) =>
-      delay({ result: 'ok' as const, message: `Connected to ${body.provider}`, provider: body.provider }),
+      delay({
+        result: 'ok' as const,
+        message: `Connected to ${body.provider}`,
+        provider: body.provider,
+      }),
     getFeatures: () => delay({ features }),
     toggleFeature: (key, enabled) => {
-      features = features.map((f) => (f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f));
+      features = features.map((f) =>
+        f.key === key ? { ...f, enabled: enabled ?? !f.enabled } : f,
+      );
       const updated = features.find((f) => f.key === key)!;
-      return delay({ feature: { key: updated.key, package: updated.package, enabled: updated.enabled } });
+      return delay({
+        feature: { key: updated.key, package: updated.package, enabled: updated.enabled },
+      });
     },
     getUsage: () => delay(usage),
   };

--- a/packages/react/src/components/ai/types.ts
+++ b/packages/react/src/components/ai/types.ts
@@ -1,0 +1,105 @@
+/** @module ai/types */
+
+/** Public credential payload returned from GET `/settings`. Never contains the plaintext API key. */
+export interface AiCredentials {
+  provider: string;
+  api_key_present: boolean;
+  base_url: string | null;
+  default_model: string | null;
+}
+
+/** Per-feature override row returned from GET `/settings`. */
+export interface AiFeatureOverride {
+  feature_key: string;
+  package: string;
+  model: string | null;
+  instructions: string | null;
+}
+
+/** Combined settings payload from GET `/settings`. */
+export interface AiSettingsResponse {
+  credentials: AiCredentials;
+  feature_overrides: AiFeatureOverride[];
+}
+
+/** Body for PUT `/settings`. `api_key` is optional; omit to keep the stored key. */
+export interface AiSettingsUpdate {
+  provider: string;
+  api_key?: string | null;
+  base_url?: string | null;
+  default_model?: string | null;
+  feature_overrides?: Array<Pick<AiFeatureOverride, 'feature_key' | 'model' | 'instructions'>>;
+}
+
+/** Feature row returned from GET `/features`. */
+export interface AiFeature {
+  key: string;
+  package: string;
+  label: string;
+  description: string | null;
+  enabled: boolean;
+}
+
+/** Response from POST `/test-connection`. */
+export interface AiConnectionTestResult {
+  result: 'ok' | 'error';
+  message?: string;
+  provider?: string;
+  model?: string | null;
+}
+
+/** Usage totals block from GET `/usage`. */
+export interface AiUsageTotals {
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Per-feature usage row. */
+export interface AiUsageByFeature {
+  feature_key: string;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Daily usage bucket. */
+export interface AiUsageDaily {
+  period: string;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+/** Full response body of GET `/usage`. */
+export interface AiUsageResponse {
+  range: { from: string; to: string };
+  totals: AiUsageTotals;
+  by_feature: AiUsageByFeature[];
+  daily: AiUsageDaily[];
+}
+
+/** Validation error envelope returned by 422 responses. */
+export interface AiValidationError {
+  message: string;
+  errors: Record<string, string[]>;
+}
+
+/**
+ * Minimal HTTP client contract. Callers inject their own fetch wrapper
+ * (typically pre-configured with base URL, CSRF token, and Accept: application/json).
+ */
+export interface AiApiClient {
+  getSettings(): Promise<AiSettingsResponse>;
+  updateSettings(body: AiSettingsUpdate): Promise<AiSettingsResponse>;
+  testConnection(body: Omit<AiSettingsUpdate, 'feature_overrides'>): Promise<AiConnectionTestResult>;
+  getFeatures(): Promise<{ features: AiFeature[] }>;
+  toggleFeature(key: string, enabled?: boolean): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
+  getUsage(params?: { from?: string; to?: string }): Promise<AiUsageResponse>;
+}

--- a/packages/react/src/components/ai/types.ts
+++ b/packages/react/src/components/ai/types.ts
@@ -98,8 +98,13 @@ export interface AiValidationError {
 export interface AiApiClient {
   getSettings(): Promise<AiSettingsResponse>;
   updateSettings(body: AiSettingsUpdate): Promise<AiSettingsResponse>;
-  testConnection(body: Omit<AiSettingsUpdate, 'feature_overrides'>): Promise<AiConnectionTestResult>;
+  testConnection(
+    body: Omit<AiSettingsUpdate, 'feature_overrides'>,
+  ): Promise<AiConnectionTestResult>;
   getFeatures(): Promise<{ features: AiFeature[] }>;
-  toggleFeature(key: string, enabled?: boolean): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
+  toggleFeature(
+    key: string,
+    enabled?: boolean,
+  ): Promise<{ feature: Pick<AiFeature, 'key' | 'package' | 'enabled'> }>;
   getUsage(params?: { from?: string; to?: string }): Promise<AiUsageResponse>;
 }

--- a/packages/react/src/components/ai/useStreamingText.ts
+++ b/packages/react/src/components/ai/useStreamingText.ts
@@ -71,7 +71,6 @@ export function useStreamingText(): UseStreamingTextResult {
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       // Read until the stream closes; append decoded chunks to accumulated text.
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;

--- a/packages/react/src/components/ai/useStreamingText.ts
+++ b/packages/react/src/components/ai/useStreamingText.ts
@@ -1,0 +1,100 @@
+/** @module ai/useStreamingText */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Result of the {@link useStreamingText} hook.
+ */
+export interface UseStreamingTextResult {
+  /** Accumulated text chunks received so far. */
+  text: string;
+  /** True while a stream is actively being consumed. */
+  streaming: boolean;
+  /** Populated when the stream ends with an error. */
+  error: Error | null;
+  /**
+   * Kick off a stream from the given URL. Aborts any in-flight stream first.
+   * Chunks decoded from `Response.body` are appended to `text` as they arrive.
+   */
+  start: (url: string, init?: RequestInit) => Promise<void>;
+  /** Abort the in-flight stream, if any. */
+  stop: () => void;
+  /** Reset accumulated text and error state. */
+  reset: () => void;
+}
+
+/**
+ * Consume a long-running fetch response as a UTF-8 text stream, appending
+ * decoded chunks to an accumulating `text` string on each read.
+ *
+ * Wraps the browser Streams API and supports abort via {@link stop} or unmount.
+ * Useful for the AI usage dashboard's long-running agent output surface.
+ *
+ * @example
+ * ```tsx
+ * const { text, streaming, start, stop } = useStreamingText();
+ * useEffect(() => { start('/api/artisanpack-ai/agent/stream'); }, []);
+ * return <pre>{text}{streaming && '…'}</pre>;
+ * ```
+ */
+export function useStreamingText(): UseStreamingTextResult {
+  const [text, setText] = useState('');
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setStreaming(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    setText('');
+    setError(null);
+  }, []);
+
+  const start = useCallback(async (url: string, init?: RequestInit) => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setText('');
+    setError(null);
+    setStreaming(true);
+
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal });
+      if (!response.ok || !response.body) {
+        throw new Error(`Stream request failed with status ${response.status}`);
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      // Read until the stream closes; append decoded chunks to accumulated text.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        setText((prev) => prev + decoder.decode(value, { stream: true }));
+      }
+      setText((prev) => prev + decoder.decode());
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setError(err as Error);
+      }
+    } finally {
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+      }
+      setStreaming(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
+
+  return { text, streaming, error, start, stop, reset };
+}

--- a/packages/react/src/components/ai/useStreamingText.ts
+++ b/packages/react/src/components/ai/useStreamingText.ts
@@ -82,10 +82,14 @@ export function useStreamingText(): UseStreamingTextResult {
         setError(err as Error);
       }
     } finally {
+      // Only flip streaming off if we're still the active stream. Otherwise
+      // a rapid second start() would race: this stream's finally would clear
+      // the flag while the newer stream is still reading, and consumers gating
+      // spinners on `streaming` would render as done mid-stream.
       if (controllerRef.current === controller) {
         controllerRef.current = null;
+        setStreaming(false);
       }
-      setStreaming(false);
     }
   }, []);
 

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     chart: 'src/components/data/Chart/Chart.tsx',
     feedback: 'src/components/feedback/index.ts',
     utility: 'src/components/utility/index.ts',
+    ai: 'src/components/ai/index.ts',
   },
   format: ['esm'],
   dts: true,

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @artisanpack-ui/tokens
 
+## 1.0.2
+
+### Patch Changes
+
+- Linked version bump alongside `@artisanpack-ui/react@1.0.2` and `@artisanpack-ui/react-laravel@1.0.2`. No source changes in this package.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artisanpack-ui/tokens",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared design tokens, color resolver, and glass helpers for ArtisanPack UI",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Release 1.0.2

Ships the `@artisanpack-ui/react/ai` subpath — drop-in React components + hooks that consume the [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai) JSON API. Gives React starter kits admin surfaces at parity with the ai package's Livewire pages, without pulling in Livewire.

### Highlights

- **`SettingsPage`** — GET/PUT `/settings` + `test-connection` probe, per-feature overrides, provider-switch clears the typed key
- **`UsageDashboard`** — GET `/usage` with sequence-guarded polling via `refreshInterval`
- **`FeatureToggles`** — optimistic POST `/features/{key}/toggle` with rollback on failure
- **`createAiApiClient`** — small `fetch` wrapper with `AiApiError` for 422 handling
- **`useStreamingText`** — hook that consumes long-running `fetch` streams via Streams API + `AbortController`
- Storybook stories for every component + 19 new Vitest cases

Linked package bumps: `@artisanpack-ui/tokens@1.0.2` and `@artisanpack-ui/react-laravel@1.0.2` (no source changes in either — matches how 1.0.1 shipped).

Closes ArtisanPack-UI/ai#17.

### Checklist

- [x] Version numbers consistent across all files (1.0.2 in `packages/tokens/package.json`, `packages/react/package.json`, `packages/react-laravel/package.json`, and `package-lock.json`)
- [x] Root `CHANGELOG.md` and each per-package `CHANGELOG.md` updated with the 1.0.2 entry
- [x] Docs: new `docs/AI-Components.md` wiki page wired into `_Sidebar.md` + `Home.md`
- [x] Lock file in sync (`npm install --package-lock-only`)
- [x] Security scan: 0 production vulnerabilities (7 dev-only, pre-existing on `main`)
- [x] Prettier + ESLint clean, `tsc --noEmit` clean
- [x] Tests passing: tokens 74, react 734, react-laravel 56

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new AI section to the React package with settings, usage, and feature toggle UI.
  * Introduced a client for AI-related API calls and a streaming text hook.
  * Added Storybook coverage and documentation for the new AI components.

* **Bug Fixes**
  * Improved loading, error, and retry behavior across the new AI screens.
  * Added tests covering form validation, polling, toggle rollback, and streaming behavior.

* **Chores**
  * Bumped package versions and updated changelogs to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->